### PR TITLE
tidy tests for `log_lik`, `res`, `ran`, and `dev` (#33)

### DIFF
--- a/tests/testthat/_snaps/dev.md
+++ b/tests/testthat/_snaps/dev.md
@@ -1,4 +1,4 @@
-# gamma_pois deviance snapshot
+# dev_gamma_pois deviance snapshot
 
     Code
       withr::with_seed(101, {

--- a/tests/testthat/_snaps/log-lik.md
+++ b/tests/testthat/_snaps/log-lik.md
@@ -1,4 +1,4 @@
-# beta_binom log_lik
+# log_lik_beta_binom log_lik
 
     Code
       log_lik_beta_binom(x = samples, size = 50, prob = 0.2, theta = 1.1)

--- a/tests/testthat/test-dev.R
+++ b/tests/testthat/test-dev.R
@@ -1,12 +1,15 @@
-test_that("beta_binom missing values", {
-  expect_identical(dev_beta_binom(logical(0), integer(0), numeric(0), numeric(0)), numeric(0))
+test_that("dev_beta_binom missing values", {
+  expect_identical(
+    dev_beta_binom(logical(0), integer(0), numeric(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(dev_beta_binom(NA, 1, 1, 1), NA_real_)
   expect_identical(dev_beta_binom(1, NA, 1, 1), NA_real_)
   expect_identical(dev_beta_binom(1, 1, NA, 1), NA_real_)
   expect_identical(dev_beta_binom(1, 1, 1, NA), NA_real_)
 })
 
-test_that("beta_binom known values", {
+test_that("dev_beta_binom known values", {
   expect_equal(dev_beta_binom(1), 1.38629436111989)
   expect_equal(dev_beta_binom(1, 1, 0), Inf)
   expect_equal(dev_beta_binom(1, 1, 0, 0.5), Inf)
@@ -18,8 +21,10 @@ test_that("beta_binom known values", {
   expect_equal(dev_beta_binom(1, 2, 0.2, 1), 0.892574205256839)
   expect_equal(dev_beta_binom(1, 2, 0.2, 0.5), 0.892574205256839)
   expect_equal(dev_beta_binom(1, 5, 0.3, 0), 0.257320924779852)
-  expect_equal(dev_beta_binom(1, 5, 0.3, 1), 5.7171585443605e-05) # was negative with naive sat. model
-  expect_equal(dev_beta_binom(1, 5, 0.3, 0.5), 0.0274314034251604) # was negative with naive sat. model
+  # was negative with naive sat. model
+  expect_equal(dev_beta_binom(1, 5, 0.3, 1), 5.7171585443605e-05)
+  # was negative with naive sat. model
+  expect_equal(dev_beta_binom(1, 5, 0.3, 0.5), 0.0274314034251604)
   expect_identical(dev_beta_binom(1, 1, 1, 0.5), 0)
   expect_identical(dev_beta_binom(1, 1, 1), 0)
   expect_identical(dev_beta_binom(1, 1, 1, 1), 0)
@@ -47,14 +52,20 @@ test_that("beta_binom known values", {
   expect_equal(dev_beta_binom(0, 2, 0, 10), 0)
 })
 
-test_that("beta_binom vectorized", {
+test_that("dev_beta_binom vectorized", {
   expect_equal(dev_beta_binom(0:3, 5, 0, 0), dev_binom(0:3, 5, 0))
-  expect_equal(dev_beta_binom(c(0, 1, 3, 0), 3, 0.5, 0.5), c(3.2188758248682, 0.179750127270293, 3.2188758248682, 3.2188758248682))
+  expect_equal(
+    dev_beta_binom(c(0, 1, 3, 0), 3, 0.5, 0.5),
+    c(3.2188758248682, 0.179750127270293, 3.2188758248682, 3.2188758248682)
+  )
   expect_equal(dev_beta_binom(0:3, 0:3, rep(1, 4), 0), rep(0, 4))
-  expect_equal(dev_beta_binom(0:3, 1:4, seq(0, 1, length.out = 4), 0:3), c(0, 0.235566071312767, 0.076961041136129, Inf))
+  expect_equal(
+    dev_beta_binom(0:3, 1:4, seq(0, 1, length.out = 4), 0:3),
+    c(0, 0.235566071312767, 0.076961041136129, Inf)
+  )
 })
 
-test_that("beta_binom vectorized missing values", {
+test_that("dev_beta_binom vectorized missing values", {
   expect_equal(dev_beta_binom(c(NA, 1), 0:1, 0:1, 0:1), c(NA, 0))
   expect_equal(dev_beta_binom(c(0, NA), 0:1, 0:1, 0:1), c(0, NA))
   expect_equal(dev_beta_binom(c(0:1), c(NA, 1), 0:1, 0:1), c(NA, 0))
@@ -65,36 +76,45 @@ test_that("beta_binom vectorized missing values", {
   expect_equal(dev_beta_binom(c(0:1), c(0:1), 0:1, c(0, NA)), c(0, NA))
 })
 
-test_that("beta_binom res", {
-  expect_equal(dev_beta_binom(1, 3, 0.5, 0.5), dev_beta_binom(1, 3, 0.5, 0.5, res = TRUE)^2)
-  expect_equal(dev_beta_binom(0:1, c(2, 4), 0.5, 5), dev_beta_binom(0:1, c(2, 4), 0.5, 5, res = TRUE)^2)
+test_that("dev_beta_binom res", {
+  expect_equal(
+    dev_beta_binom(1, 3, 0.5, 0.5),
+    dev_beta_binom(1, 3, 0.5, 0.5, res = TRUE)^2
+  )
+  expect_equal(
+    dev_beta_binom(0:1, c(2, 4), 0.5, 5),
+    dev_beta_binom(0:1, c(2, 4), 0.5, 5, res = TRUE)^2
+  )
 })
 
-test_that("beta_binom ran", {
-  set.seed(101)
-  samples <- ran_beta_binom(100000, 100, 0.5, 0.01)
-  expect_equal(mean(samples), 49.99347)
-  expect_equal(var(samples), 37.4491218503185)
-  res <- dev_beta_binom(samples, 100, 0.5, 0.01, res = TRUE)
-  expect_equal(mean(res), -0.00107466576791911, tolerance = 1e-04) # for M1
-  expect_equal(sd(res), 1.0040052194768)
+test_that("dev_beta_binom ran", {
+  withr::with_seed(101, {
+    samples <- ran_beta_binom(100000, 100, 0.5, 0.01)
+    expect_equal(mean(samples), 49.99347)
+    expect_equal(var(samples), 37.4491218503185)
+    res <- dev_beta_binom(samples, 100, 0.5, 0.01, res = TRUE)
+    expect_equal(mean(res), -0.00107466576791911, tolerance = 1e-04) # for M1
+    expect_equal(sd(res), 1.0040052194768)
+  })
 })
 
-test_that("deviance beta_binom", {
-  samples <- ran_beta_binom(100, size = 3, prob = 0.5, theta = 0) # binomial case.
+test_that("dev_beta_binom deviance", {
+  # binomial case.
+  samples <- ran_beta_binom(100, size = 3, prob = 0.5, theta = 0)
   mod <- glm(cbind(samples, 3 - samples) ~ 1, family = binomial)
-  deviance <- sum(dev_beta_binom(samples, size = 3, ilogit(coef(mod)[1])), theta = 0)
+  deviance <- sum(
+    dev_beta_binom(samples, size = 3, ilogit(coef(mod)[1])), theta = 0
+  )
   expect_equal(deviance, deviance(mod))
-  # no packages that calculate deviance using binomial saturated model.
 })
 
-test_that("bern missing values", {
+test_that("dev_bern missing values", {
   expect_identical(dev_bern(logical(0), integer(0)), numeric(0))
   expect_identical(dev_bern(NA, 1), NA_real_)
   expect_identical(dev_bern(1, NA), NA_real_)
 })
 
-test_that("bern known values", {
+test_that("dev_bern known values", {
   expect_identical(dev_bern(1, 1), 0)
   expect_identical(dev_bern(0, 0), 0)
   expect_identical(dev_bern(1, 0), Inf)
@@ -105,13 +125,16 @@ test_that("bern known values", {
   expect_equal(dev_bern(0, 0.7), 2.40794560865187)
 })
 
-test_that("bern vectorized", {
+test_that("dev_bern vectorized", {
   expect_equal(dev_bern(0:1, 0:1), c(0, 0))
   expect_equal(dev_bern(0:1, 1:0), c(Inf, Inf))
-  expect_equal(dev_bern(0:1, c(0.3, 0.6)), c(0.713349887877465, 1.02165124753198))
+  expect_equal(
+    dev_bern(0:1, c(0.3, 0.6)),
+    c(0.713349887877465, 1.02165124753198)
+  )
 })
 
-test_that("bern vectorized missing values", {
+test_that("dev_bern vectorized missing values", {
   expect_equal(dev_bern(c(NA, 1), 0:1), c(NA, 0))
   expect_equal(dev_bern(c(0, NA), 0:1), c(0, NA))
   expect_equal(dev_bern(c(0:1), c(NA, 1)), c(NA, 0))
@@ -120,10 +143,13 @@ test_that("bern vectorized missing values", {
 
 test_that("dev_bern res", {
   expect_equal(dev_bern(0, 0.5), dev_bern(0, 0.5, res = TRUE)^2)
-  expect_equal(dev_bern(0:1, c(0.3, 0.6)), dev_bern(0:1, c(0.3, 0.6), res = TRUE)^2)
+  expect_equal(
+    dev_bern(0:1, c(0.3, 0.6)),
+    dev_bern(0:1, c(0.3, 0.6), res = TRUE)^2
+  )
 })
 
-test_that("bern log_lik", {
+test_that("dev_bern log_lik", {
   expect_equal(
     dev_bern(0:1, 0.5),
     2 * (log_lik_bern(0:1, 0:1) - log_lik_bern(0:1, 0.5))
@@ -134,19 +160,20 @@ test_that("bern log_lik", {
   )
 })
 
-test_that("bern deviance", {
+test_that("dev_bern deviance", {
   samples <- ran_bern(1000)
   mod <- glm(cbind(samples, 1 - samples) ~ 1, family = binomial)
   deviance <- sum(dev_bern(samples, ilogit(coef(mod)[1])))
   expect_equal(deviance, deviance(mod))
 })
 
-test_that("bern ran", {
-  set.seed(101)
-  samples <- ran_bern(1000)
-  res <- dev_bern(samples, res = TRUE)
-  expect_equal(mean(res), -0.0494512209456499)
-  expect_equal(sd(res), 1.17695971555483)
+test_that("dev_bern ran", {
+  withr::with_seed(101, {
+    samples <- ran_bern(1000)
+    res <- dev_bern(samples, res = TRUE)
+    expect_equal(mean(res), -0.0494512209456499)
+    expect_equal(sd(res), 1.17695971555483)
+  })
 })
 
 test_that("dev_binom", {
@@ -165,34 +192,39 @@ test_that("dev_binom", {
   expect_equal(
     dev_binom(1:9, 10, 0.5, res = TRUE),
     c(
-      -2.71316865369073, -1.96338868806845, -1.28283185573988, -0.634594572159089,
-      0, 0.634594572159089, 1.28283185573988, 1.96338868806845, 2.71316865369073
+      -2.71316865369073, -1.96338868806845,
+      -1.28283185573988, -0.634594572159089,
+      0, 0.634594572159089,
+      1.28283185573988, 1.96338868806845, 2.71316865369073
     )
   )
 })
 
-test_that("deviance binom log_lik", {
+test_that("dev_binom log_lik", {
   expect_equal(
     dev_binom(0:3, 3, 0.5),
     2 * (log_lik_binom(0:3, 3, 0:3 / 3) - log_lik_binom(0:3, 3, 0.5))
   )
 })
 
-test_that("deviance binom", {
+test_that("dev_binom deviance", {
   samples <- ran_binom(100, 3)
   mod <- glm(cbind(samples, 3 - samples) ~ 1, family = binomial)
   deviance <- sum(dev_binom(samples, size = 3, ilogit(coef(mod)[1])))
   expect_equal(deviance, deviance(mod))
 })
 
-test_that("gamma_pois missing values", {
-  expect_identical(dev_gamma_pois(logical(0), integer(0), numeric(0)), numeric(0))
+test_that("dev_gamma_pois missing values", {
+  expect_identical(
+    dev_gamma_pois(logical(0), integer(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(dev_gamma_pois(NA, 1), NA_real_)
   expect_identical(dev_gamma_pois(1, NA), NA_real_)
   expect_identical(dev_gamma_pois(1, 1, NA), NA_real_)
 })
 
-test_that("gamma_pois known values", {
+test_that("dev_gamma_pois known values", {
   expect_identical(dev_gamma_pois(1, 1), 0)
   expect_identical(dev_gamma_pois(1, 1, 1), 0)
   expect_identical(dev_gamma_pois(0, 0), 0)
@@ -206,13 +238,19 @@ test_that("gamma_pois known values", {
   expect_equal(dev_gamma_pois(0, 2, 2), 1.6094379124341)
 })
 
-test_that("gamma_pois vectorized", {
-  expect_equal(dev_gamma_pois(0:3, 2, 0), c(4, 0.613705638880109, 0, 0.432790648648986))
+test_that("dev_gamma_pois vectorized", {
+  expect_equal(
+    dev_gamma_pois(0:3, 2, 0),
+    c(4, 0.613705638880109, 0, 0.432790648648986)
+  )
   expect_equal(dev_gamma_pois(0:3, 0:3, rep(1, 4)), rep(0, 4))
-  expect_equal(dev_gamma_pois(0:3, 3:0, 0:3), c(6, 0.235566071312767, 0.218460603409828, Inf))
+  expect_equal(
+    dev_gamma_pois(0:3, 3:0, 0:3),
+    c(6, 0.235566071312767, 0.218460603409828, Inf)
+  )
 })
 
-test_that("gamma_pois vectorized missing values", {
+test_that("dev_gamma_pois vectorized missing values", {
   expect_equal(dev_gamma_pois(c(NA, 1), 0:1, 0:1), c(NA, 0))
   expect_equal(dev_gamma_pois(c(0, NA), 0:1, 0:1), c(0, NA))
   expect_equal(dev_gamma_pois(c(0:1), c(NA, 1), 0:1), c(NA, 0))
@@ -221,12 +259,15 @@ test_that("gamma_pois vectorized missing values", {
   expect_equal(dev_gamma_pois(c(0:1), c(0:1), c(0, NA)), c(0, NA))
 })
 
-test_that("gamma_pois res", {
+test_that("dev_gamma_pois res", {
   expect_equal(dev_gamma_pois(0, 0.5), dev_gamma_pois(0, 0.5, res = TRUE)^2)
-  expect_equal(dev_gamma_pois(0:1, c(0.3, 0.6)), dev_gamma_pois(0:1, c(0.3, 0.6), res = TRUE)^2)
+  expect_equal(
+    dev_gamma_pois(0:1, c(0.3, 0.6)),
+    dev_gamma_pois(0:1, c(0.3, 0.6), res = TRUE)^2
+  )
 })
 
-test_that("gamma_pois log_lik", {
+test_that("dev_gamma_pois log_lik", {
   expect_equal(
     dev_gamma_pois(0:1, 0.5),
     2 * (log_lik_gamma_pois(0:1, 0:1) - log_lik_gamma_pois(0:1, 0.5))
@@ -251,11 +292,13 @@ test_that("gamma_pois log_lik", {
 #   skip_if_not_installed("MASS")
 #   samples <- ran_gamma_pois(10000, 3, 0.5)
 #   mod <- MASS::glm.nb(samples ~ 1)
-#   deviance <- sum(dev_gamma_pois(samples, exp(coef(mod)[1]), theta = 1 / mod$theta))
+#   deviance <- sum(dev_gamma_pois(
+#     samples, exp(coef(mod)[1]), theta = 1 / mod$theta
+#   ))
 #   expect_equal(deviance, deviance(mod))
 # })
 
-test_that("gamma_pois deviance snapshot", {
+test_that("dev_gamma_pois deviance snapshot", {
   expect_snapshot({
     withr::with_seed(
       101,
@@ -268,25 +311,29 @@ test_that("gamma_pois deviance snapshot", {
   })
 })
 
-test_that("gamma_pois ran", {
-  set.seed(100)
-  samples <- ran_gamma_pois(100000, 3, 0.5)
-  expect_equal(mean(samples), 3.00867)
-  expect_equal(var(samples), 7.50806991179912)
-  res <- dev_gamma_pois(samples, 3, 0.5, res = TRUE)
-  expect_equal(mean(res), -0.260848965857529)
-  expect_equal(sd(res), 1.0243876393499)
+test_that("dev_gamma_pois ran", {
+  withr::with_seed(100, {
+    samples <- ran_gamma_pois(100000, 3, 0.5)
+    expect_equal(mean(samples), 3.00867)
+    expect_equal(var(samples), 7.50806991179912)
+    res <- dev_gamma_pois(samples, 3, 0.5, res = TRUE)
+    expect_equal(mean(res), -0.260848965857529)
+    expect_equal(sd(res), 1.0243876393499)
+  })
 })
 
-test_that("gamma_pois_zi missing values", {
-  expect_identical(dev_gamma_pois_zi(logical(0), integer(0), numeric(0), numeric(0)), numeric(0))
+test_that("dev_gamma_pois_zi missing values", {
+  expect_identical(
+    dev_gamma_pois_zi(logical(0), integer(0), numeric(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(dev_gamma_pois_zi(NA, 1, 1, 1), NA_real_)
   expect_identical(dev_gamma_pois_zi(1, NA, 1, 1), NA_real_)
   expect_identical(dev_gamma_pois_zi(1, 1, NA, 1), NA_real_)
   expect_identical(dev_gamma_pois_zi(1, 1, 1, NA), NA_real_)
 })
 
-test_that("gamma_pois_zi known values", {
+test_that("dev_gamma_pois_zi known values", {
   expect_identical(dev_gamma_pois_zi(1, 1), 0)
   expect_identical(dev_gamma_pois_zi(1, 1, 1), 0)
   expect_identical(dev_gamma_pois_zi(1, 1, 1, 1), Inf)
@@ -309,14 +356,23 @@ test_that("gamma_pois_zi known values", {
   expect_equal(dev_gamma_pois_zi(0, 2, 2, 0.5), 0.647014262314894)
 })
 
-test_that("gamma_pois_zi vectorized", {
-  expect_equal(dev_gamma_pois_zi(0:3, 2, 0, 0), c(4, 0.613705638880109, 0, 0.432790648648986))
-  expect_equal(dev_gamma_pois_zi(c(0, 1, 3, 0), 3, 0.5, 0.5), c(1.08945435088334, 2.25402352637961, 1.38629436111989, 1.08945435088334))
+test_that("dev_gamma_pois_zi vectorized", {
+  expect_equal(
+    dev_gamma_pois_zi(0:3, 2, 0, 0),
+    c(4, 0.613705638880109, 0, 0.432790648648986)
+  )
+  expect_equal(
+    dev_gamma_pois_zi(c(0, 1, 3, 0), 3, 0.5, 0.5),
+    c(1.08945435088334, 2.25402352637961, 1.38629436111989, 1.08945435088334)
+  )
   expect_equal(dev_gamma_pois_zi(0:3, 0:3, rep(1, 4), 0), rep(0, 4))
-  expect_equal(dev_gamma_pois_zi(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)), c(6, 1.0464962875291, 2.41568518074605, Inf))
+  expect_equal(
+    dev_gamma_pois_zi(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)),
+    c(6, 1.0464962875291, 2.41568518074605, Inf)
+  )
 })
 
-test_that("gamma_pois_zi vectorized missing values", {
+test_that("dev_gamma_pois_zi vectorized missing values", {
   expect_equal(dev_gamma_pois_zi(c(NA, 1), 0:1, 0:1, 0:1), c(NA, Inf))
   expect_equal(dev_gamma_pois_zi(c(0, NA), 0:1, 0:1, 0:1), c(0, NA))
   expect_equal(dev_gamma_pois_zi(c(0:1), c(NA, 1), 0:1, 0:1), c(NA, Inf))
@@ -327,12 +383,18 @@ test_that("gamma_pois_zi vectorized missing values", {
   expect_equal(dev_gamma_pois_zi(c(0:1), c(0:1), 0:1, c(0, NA)), c(0, NA))
 })
 
-test_that("gamma_pois_zi res", {
-  expect_equal(dev_gamma_pois_zi(0, 0.5, 0.5), dev_gamma_pois_zi(0, 0.5, 0.5, res = TRUE)^2)
-  expect_equal(dev_gamma_pois_zi(0:1, c(0.3, 0.6), 0.5), dev_gamma_pois_zi(0:1, c(0.3, 0.6), 0.5, res = TRUE)^2)
+test_that("dev_gamma_pois_zi res", {
+  expect_equal(
+    dev_gamma_pois_zi(0, 0.5, 0.5),
+    dev_gamma_pois_zi(0, 0.5, 0.5, res = TRUE)^2
+  )
+  expect_equal(
+    dev_gamma_pois_zi(0:1, c(0.3, 0.6), 0.5),
+    dev_gamma_pois_zi(0:1, c(0.3, 0.6), 0.5, res = TRUE)^2
+  )
 })
 
-test_that("gamma_pois_zi log_lik", {
+test_that("dev_gamma_pois_zi log_lik", {
   expect_equal(
     dev_gamma_pois_zi(0:1, 0.5),
     2 * (log_lik_gamma_pois_zi(0:1, 0:1) - log_lik_gamma_pois_zi(0:1, 0.5))
@@ -343,22 +405,25 @@ test_that("gamma_pois_zi log_lik", {
   )
   expect_equal(
     dev_gamma_pois_zi(0:1, 0.7, 1),
-    2 * (log_lik_gamma_pois_zi(0:1, 0:1, 1) - log_lik_gamma_pois_zi(0:1, 0.7, 1))
+    2 * (log_lik_gamma_pois_zi(0:1, 0:1, 1) -
+      log_lik_gamma_pois_zi(0:1, 0.7, 1))
   )
   expect_equal(
     dev_gamma_pois_zi(0:1, 0.7, 1, 0.5),
-    2 * (log_lik_gamma_pois_zi(0:1, 0:1, 1) - log_lik_gamma_pois_zi(0:1, 0.7, 1, 0.5))
+    2 * (log_lik_gamma_pois_zi(0:1, 0:1, 1) -
+      log_lik_gamma_pois_zi(0:1, 0.7, 1, 0.5))
   )
 })
 
-test_that("gamma_pois_zi ran", {
-  set.seed(100)
-  samples <- ran_gamma_pois_zi(100000, 3, 0.5, 0.5)
-  expect_equal(mean(samples), 1.51352)
-  expect_equal(var(samples), 6.07855799517995)
-  res <- dev_gamma_pois_zi(samples, 3, 0.5, 0.5, res = TRUE)
-  expect_equal(mean(res), -0.299429507479032)
-  expect_equal(sd(res), 1.18261741535124)
+test_that("dev_gamma_pois_zi ran", {
+  withr::with_seed(100, {
+    samples <- ran_gamma_pois_zi(100000, 3, 0.5, 0.5)
+    expect_equal(mean(samples), 1.51352)
+    expect_equal(var(samples), 6.07855799517995)
+    res <- dev_gamma_pois_zi(samples, 3, 0.5, 0.5, res = TRUE)
+    expect_equal(mean(res), -0.299429507479032)
+    expect_equal(sd(res), 1.18261741535124)
+  })
 })
 
 test_that("dev_lnorm", {
@@ -378,8 +443,14 @@ test_that("dev_lnorm", {
   expect_identical(dev_lnorm(1, 1, NA), NA_real_)
   expect_equal(dev_lnorm(-2), dev_lnorm(-2, res = TRUE)^2)
   expect_equal(dev_lnorm(exp(-2:2), res = TRUE), c(-2, -1, 0, 1, 2))
-  expect_equal(dev_lnorm(exp(-2:2), sdlog = 2, res = TRUE), dev_norm(-2:2, res = TRUE) / 2)
-  expect_equal(dev_lnorm(exp(-2:2), sdlog = 1 / 2, res = TRUE), dev_norm(-2:2, res = TRUE) * 2)
+  expect_equal(
+    dev_lnorm(exp(-2:2), sdlog = 2, res = TRUE),
+    dev_norm(-2:2, res = TRUE) / 2
+  )
+  expect_equal(
+    dev_lnorm(exp(-2:2), sdlog = 1 / 2, res = TRUE),
+    dev_norm(-2:2, res = TRUE) * 2
+  )
   expect_equal(dev_lnorm(exp(-2:2), meanlog = -2:2), rep(0, 5))
   expect_equal(
     dev_lnorm(exp(-2:2), meanlog = -1:3, sdlog = 1:5, res = TRUE),
@@ -387,15 +458,18 @@ test_that("dev_lnorm", {
   )
 })
 
-test_that("deviance lnorm", {
+test_that("dev_lnorm deviance", {
   samples <- ran_lnorm(100)
   mod <- lm(log(samples) ~ 1)
   deviance <- sum(dev_lnorm(samples, coef(mod)[1]))
   expect_equal(deviance, deviance(mod))
 })
 
-test_that("dev_neg_bin", {
-  expect_identical(dev_neg_binom(integer(0), integer(0), integer(0)), numeric(0))
+test_that("dev_neg_binom", {
+  expect_identical(
+    dev_neg_binom(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(dev_neg_binom(1, 1, 0), 0)
   expect_identical(dev_neg_binom(1, 1, 1), 0)
   expect_identical(dev_neg_binom(0, 1, 0), 2)
@@ -430,8 +504,14 @@ test_that("dev_norm", {
   expect_identical(dev_norm(1, 1, NA), NA_real_)
   expect_equal(dev_norm(-2), dev_norm(-2, res = TRUE)^2)
   expect_equal(dev_norm(-2:2, res = TRUE), c(-2, -1, 0, 1, 2))
-  expect_equal(dev_norm(-2:2, sd = 2, res = TRUE), dev_norm(-2:2, res = TRUE) / 2)
-  expect_equal(dev_norm(-2:2, sd = 1 / 2, res = TRUE), dev_norm(-2:2, res = TRUE) * 2)
+  expect_equal(
+    dev_norm(-2:2, sd = 2, res = TRUE),
+    dev_norm(-2:2, res = TRUE) / 2
+  )
+  expect_equal(
+    dev_norm(-2:2, sd = 1 / 2, res = TRUE),
+    dev_norm(-2:2, res = TRUE) * 2
+  )
   expect_equal(dev_norm(-2:2, mean = -2:2, res = TRUE), rep(0, 5))
   expect_equal(
     dev_norm(-2:2, mean = -1:3, sd = 1:5, res = TRUE),
@@ -439,20 +519,20 @@ test_that("dev_norm", {
   )
 })
 
-test_that("deviance norm", {
+test_that("dev_norm deviance", {
   samples <- ran_norm(100)
   mod <- lm(samples ~ 1)
   deviance <- sum(dev_norm(samples, coef(mod)[1]))
   expect_equal(deviance, deviance(mod))
 })
 
-test_that("pois missing values", {
+test_that("dev_pois missing values", {
   expect_identical(dev_pois(logical(0), integer(0)), numeric(0))
   expect_identical(dev_pois(NA, 1), NA_real_)
   expect_identical(dev_pois(1, NA), NA_real_)
 })
 
-test_that("pois known values", {
+test_that("dev_pois known values", {
   expect_identical(dev_pois(1, 1), 0)
   expect_identical(dev_pois(0, 0), 0)
   expect_identical(dev_pois(1, 0), Inf)
@@ -464,25 +544,31 @@ test_that("pois known values", {
   expect_equal(dev_pois(3, 2.5), 0.0939293407637276)
 })
 
-test_that("pois vectorized", {
+test_that("dev_pois vectorized", {
   expect_equal(dev_pois(0:3, 2), c(4, 0.613705638880109, 0, 0.432790648648986))
   expect_equal(dev_pois(0:3, 0:3), rep(0, 4))
-  expect_equal(dev_pois(0:3, 3:0), c(6, 0.613705638880109, 0.772588722239781, Inf))
+  expect_equal(
+    dev_pois(0:3, 3:0),
+    c(6, 0.613705638880109, 0.772588722239781, Inf)
+  )
 })
 
-test_that("pois vectorized missing values", {
+test_that("dev_pois vectorized missing values", {
   expect_equal(dev_pois(c(NA, 1), 0:1), c(NA, 0))
   expect_equal(dev_pois(c(0, NA), 0:1), c(0, NA))
   expect_equal(dev_pois(c(0:1), c(NA, 1)), c(NA, 0))
   expect_equal(dev_pois(c(0:1), c(0, NA)), c(0, NA))
 })
 
-test_that("pois res", {
+test_that("dev_pois res", {
   expect_equal(dev_pois(0, 0.5), dev_pois(0, 0.5, res = TRUE)^2)
-  expect_equal(dev_pois(0:1, c(0.3, 0.6)), dev_pois(0:1, c(0.3, 0.6), res = TRUE)^2)
+  expect_equal(
+    dev_pois(0:1, c(0.3, 0.6)),
+    dev_pois(0:1, c(0.3, 0.6), res = TRUE)^2
+  )
 })
 
-test_that("pois log_lik", {
+test_that("dev_pois log_lik", {
   expect_equal(
     dev_pois(0:1, 0.5),
     2 * (log_lik_pois(0:1, 0:1) - log_lik_pois(0:1, 0.5))
@@ -493,31 +579,32 @@ test_that("pois log_lik", {
   )
 })
 
-test_that("pois deviance", {
+test_that("dev_pois deviance", {
   samples <- ran_pois(1000)
   mod <- glm(samples ~ 1, family = poisson)
   deviance <- sum(dev_pois(samples, exp(coef(mod)[1])))
   expect_equal(deviance, deviance(mod))
 })
 
-test_that("pois ran", {
-  set.seed(101)
-  samples <- ran_pois(1000)
-  expect_equal(mean(samples), 0.984)
-  expect_equal(var(samples), 1.02476876876877)
-  res <- dev_pois(samples, 1, res = TRUE)
-  expect_equal(mean(res), -0.235540962010425)
-  expect_equal(sd(res), 1.05758754072283)
+test_that("dev_pois ran", {
+  withr::with_seed(101, {
+    samples <- ran_pois(1000)
+    expect_equal(mean(samples), 0.984)
+    expect_equal(var(samples), 1.02476876876877)
+    res <- dev_pois(samples, 1, res = TRUE)
+    expect_equal(mean(res), -0.235540962010425)
+    expect_equal(sd(res), 1.05758754072283)
+  })
 })
 
-test_that("pois_zi missing values", {
+test_that("dev_pois_zi missing values", {
   expect_identical(dev_pois_zi(logical(0), integer(0), numeric(0)), numeric(0))
   expect_identical(dev_pois_zi(NA, 1, 1), NA_real_)
   expect_identical(dev_pois_zi(1, NA, 1), NA_real_)
   expect_identical(dev_pois_zi(1, 1, NA), NA_real_)
 })
 
-test_that("pois_zi known values", {
+test_that("dev_pois_zi known values", {
   expect_identical(dev_pois_zi(1, 1), 0)
   expect_equal(dev_pois_zi(1, 1, 0.5), 1.38629436111989)
   expect_identical(dev_pois_zi(1, 1, 1), Inf)
@@ -553,13 +640,22 @@ test_that("pois_zi known values", {
   )
 })
 
-test_that("pois_zi vectorized", {
-  expect_equal(dev_pois_zi(0:3, 2, 0), c(4, 0.613705638880109, 0, 0.432790648648986))
-  expect_equal(dev_pois_zi(0:3, 0:3, c(0, 0.1, 0.5, 1)), c(0, 0.210721031315653, 1.38629436111989, Inf))
-  expect_equal(dev_pois_zi(0:3, 3:0, c(0, 0.1, 0.5, 1)), c(6, 0.824426670195762, 2.15888308335967, Inf))
+test_that("dev_pois_zi vectorized", {
+  expect_equal(
+    dev_pois_zi(0:3, 2, 0),
+    c(4, 0.613705638880109, 0, 0.432790648648986)
+  )
+  expect_equal(
+    dev_pois_zi(0:3, 0:3, c(0, 0.1, 0.5, 1)),
+    c(0, 0.210721031315653, 1.38629436111989, Inf)
+  )
+  expect_equal(
+    dev_pois_zi(0:3, 3:0, c(0, 0.1, 0.5, 1)),
+    c(6, 0.824426670195762, 2.15888308335967, Inf)
+  )
 })
 
-test_that("pois_zi vectorized missing values", {
+test_that("dev_pois_zi vectorized missing values", {
   expect_equal(dev_pois_zi(c(NA, 1), 0:1, 0:1), c(NA, Inf))
   expect_equal(dev_pois_zi(c(0, NA), 0:1, 0:1), c(0, NA))
   expect_equal(dev_pois_zi(c(0:1), c(NA, 1), 0:1), c(NA, Inf))
@@ -568,12 +664,15 @@ test_that("pois_zi vectorized missing values", {
   expect_equal(dev_pois_zi(c(0:1), 0:1, c(1, NA)), c(0, NA))
 })
 
-test_that("pois_zi res", {
+test_that("dev_pois_zi res", {
   expect_equal(dev_pois_zi(0, 0.5, 0.5), dev_pois_zi(0, 0.5, 0.5, res = TRUE)^2)
-  expect_equal(dev_pois_zi(0:1, c(0.3, 0.6), 0.5), dev_pois_zi(0:1, c(0.3, 0.6), 0.5, res = TRUE)^2)
+  expect_equal(
+    dev_pois_zi(0:1, c(0.3, 0.6), 0.5),
+    dev_pois_zi(0:1, c(0.3, 0.6), 0.5, res = TRUE)^2
+  )
 })
 
-test_that("pois_zi log_lik", {
+test_that("dev_pois_zi log_lik", {
   expect_equal(
     dev_pois_zi(0, 0.5),
     2 * (log_lik_pois_zi(0, 0) - log_lik_pois_zi(0, 0.5))
@@ -592,24 +691,25 @@ test_that("pois_zi log_lik", {
   )
 })
 
-test_that("pois_zi ran", {
-  set.seed(101)
-  samples <- ran_pois_zi(1000, 3, 0.5)
-  expect_equal(mean(samples), 1.565)
-  expect_equal(sd(samples), 1.94462247147269)
-  res <- dev_pois_zi(samples, 3, 0.5, res = TRUE)
-  expect_equal(mean(res), -0.119914019357374)
-  expect_equal(sd(res), 1.31269320210938)
+test_that("dev_pois_zi ran", {
+  withr::with_seed(101, {
+    samples <- ran_pois_zi(1000, 3, 0.5)
+    expect_equal(mean(samples), 1.565)
+    expect_equal(sd(samples), 1.94462247147269)
+    res <- dev_pois_zi(samples, 3, 0.5, res = TRUE)
+    expect_equal(mean(res), -0.119914019357374)
+    expect_equal(sd(res), 1.31269320210938)
+  })
 })
 
-test_that("gamma missing values", {
+test_that("dev_gamma missing values", {
   expect_identical(dev_gamma(logical(0), integer(0), numeric(0)), numeric(0))
   expect_identical(dev_gamma(NA, 1, 1), NA_real_)
   expect_identical(dev_gamma(1, NA, 1), NA_real_)
   expect_identical(dev_gamma(1, 1, NA), NA_real_)
 })
 
-test_that("gamma known values", {
+test_that("dev_gamma known values", {
   expect_identical(dev_gamma(1, 1), 0)
   expect_equal(dev_gamma(1, 1, 0.5), 0.386294361119891)
   expect_identical(dev_gamma(1, 1, 1), 0)
@@ -638,8 +738,11 @@ test_that("gamma known values", {
   )
 })
 
-test_that("gamma vectorized", {
-  expect_equal(dev_gamma(0:3, 2, 1), c(Inf, 0.386294361119891, 0, 0.189069783783671))
+test_that("dev_gamma vectorized", {
+  expect_equal(
+    dev_gamma(0:3, 2, 1),
+    c(Inf, 0.386294361119891, 0, 0.189069783783671)
+  )
   expect_equal(
     dev_gamma(0:3, 1:4, c(0.1, 0.5, 1, 2)),
     c(Inf, 1.27258872223978, 0.144263549549662, 0.189069783783671)
@@ -650,7 +753,7 @@ test_that("gamma vectorized", {
   )
 })
 
-test_that("gamma vectorized missing values", {
+test_that("dev_gamma vectorized missing values", {
   expect_equal(dev_gamma(c(NA, 1), 1:2, 1:2), c(NA, 0))
   expect_equal(dev_gamma(c(0, NA), 1:2, 1:2), c(Inf, NA))
   expect_equal(dev_gamma(c(1:2), c(NA, 1), 1:2), c(NA, 3.22741127776022))
@@ -659,12 +762,16 @@ test_that("gamma vectorized missing values", {
   expect_equal(dev_gamma(c(1:2), 1:2, c(1, NA)), c(0, NA))
 })
 
-test_that("gamma res", {
+test_that("dev_gamma res", {
   expect_equal(dev_gamma(0, 0.5, 0.5), dev_gamma(0, 0.5, 0.5, res = TRUE)^2)
-  expect_equal(dev_gamma(1:2, c(0.3, 0.6), 0.5), dev_gamma(1:2, c(0.3, 0.6), 0.5, res = TRUE)^2)
+  expect_equal(
+    dev_gamma(1:2, c(0.3, 0.6), 0.5),
+    dev_gamma(1:2, c(0.3, 0.6), 0.5, res = TRUE)^2
+  )
 })
 
-test_that("gamma log_lik", { # couldn't determine exact parameter values for saturated log likelihood
+# couldn't determine exact parameter values for saturated log likelihood
+test_that("dev_gamma log_lik", {
   expect_equal(
     dev_gamma(1, 1, 1),
     2 * (log_lik_gamma(1, 1, 1) - log_lik_gamma(1, 1, 1))
@@ -680,32 +787,36 @@ test_that("gamma log_lik", { # couldn't determine exact parameter values for sat
   )
 })
 
-test_that("gamma ran", {
-  set.seed(101)
-  samples <- ran_gamma(10000, 3, 1)
-  expect_equal(mean(samples), 2.98927441565774)
-  expect_equal(sd(samples), 1.71676055992005)
-  res <- dev_gamma(samples, 3, 1, res = TRUE)
-  expect_equal(mean(res), -0.115132947326996)
-  expect_equal(sd(res), 0.579070230993174)
+test_that("dev_gamma ran", {
+  withr::with_seed(101, {
+    samples <- ran_gamma(10000, 3, 1)
+    expect_equal(mean(samples), 2.98927441565774)
+    expect_equal(sd(samples), 1.71676055992005)
+    res <- dev_gamma(samples, 3, 1, res = TRUE)
+    expect_equal(mean(res), -0.115132947326996)
+    expect_equal(sd(res), 0.579070230993174)
+  })
 })
 
-test_that("gamma deviance", {
+test_that("dev_gamma deviance", {
   samples <- ran_gamma(1000, 3, 1 / 2)
   mod <- glm(samples ~ 1, family = Gamma(link = "identity"))
   deviance <- sum(dev_gamma(samples, coef(mod)))
   expect_equal(deviance, deviance(mod))
 })
 
-test_that("student missing values", {
-  expect_identical(dev_student(logical(0), integer(0), numeric(0), numeric(0)), numeric(0))
+test_that("dev_student missing values", {
+  expect_identical(
+    dev_student(logical(0), integer(0), numeric(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(dev_student(NA, 1, 1, 1), NA_real_)
   expect_identical(dev_student(1, NA, 1, 1), NA_real_)
   expect_identical(dev_student(1, 1, NA, 1), NA_real_)
   expect_identical(dev_student(1, 1, 1, NA), NA_real_)
 })
 
-test_that("student known values", {
+test_that("dev_student known values", {
   expect_identical(dev_student(1, 1), 0)
   expect_identical(dev_student(1, 1, 1), 0)
   expect_identical(dev_student(1, 1, 1, 1), 0)
@@ -730,14 +841,20 @@ test_that("student known values", {
   expect_equal(dev_student(0, 2, 2, 0.5), 1.21639532432449)
 })
 
-test_that("student vectorized", {
+test_that("dev_student vectorized", {
   expect_equal(dev_student(0:3, 2, 0.1, 0), c(400, 100, 0, 100))
-  expect_equal(dev_student(c(0, 1, 3, 0), 3, 0.5, 0.5), c(8.83331693749932, 6.59167373200866, 0, 8.83331693749932))
+  expect_equal(
+    dev_student(c(0, 1, 3, 0), 3, 0.5, 0.5),
+    c(8.83331693749932, 6.59167373200866, 0, 8.83331693749932)
+  )
   expect_equal(dev_student(0:3, 0:3, rep(1, 4), 0), rep(0, 4))
-  expect_equal(dev_student(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)), c(Inf, 1.15072828980712, 0.385376699568146, 1.38629436111989))
+  expect_equal(
+    dev_student(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)),
+    c(Inf, 1.15072828980712, 0.385376699568146, 1.38629436111989)
+  )
 })
 
-test_that("student vectorized missing values", {
+test_that("dev_student vectorized missing values", {
   expect_equal(dev_student(c(NA, 1), 0:1, 0:1, 0:1), c(NA, 0))
   expect_equal(dev_student(c(0, NA), 0:1, 1:2, 0:1), c(0, NA))
   expect_equal(dev_student(c(0:1), c(NA, 1), 1:2, 0:1), c(NA, 0))
@@ -748,19 +865,27 @@ test_that("student vectorized missing values", {
   expect_equal(dev_student(c(0:1), c(0:1), 1:2, c(0, NA)), c(0, NA))
 })
 
-test_that("student res", {
-  expect_equal(dev_student(10, 0.5, 0.5), dev_student(10, 0.5, 0.5, res = TRUE)^2)
-  expect_equal(dev_student(0:1, c(0.3, 0.6), 0.5), dev_student(0:1, c(0.3, 0.6), 0.5, res = TRUE)^2)
+test_that("dev_student res", {
+  expect_equal(
+    dev_student(10, 0.5, 0.5),
+    dev_student(10, 0.5, 0.5, res = TRUE)^2
+  )
+  expect_equal(
+    dev_student(0:1, c(0.3, 0.6), 0.5),
+    dev_student(0:1, c(0.3, 0.6), 0.5, res = TRUE)^2
+  )
 })
 
-test_that("student log_lik", {
+test_that("dev_student log_lik", {
   expect_equal(
     dev_student(0:1, 1:2, 2:3, theta = 0),
-    2 * (log_lik_student(0:1, 0:1, 2:3, theta = 0) - log_lik_student(0:1, 1:2, 2:3, theta = 0))
+    2 * (log_lik_student(0:1, 0:1, 2:3, theta = 0) -
+      log_lik_student(0:1, 1:2, 2:3, theta = 0))
   )
   expect_equal(
     dev_student(0:1, 1:2, 2:3, theta = 0.7),
-    2 * (log_lik_student(0:1, 0:1, 2:3, theta = 0.7) - log_lik_student(0:1, 1:2, 2:3, theta = 0.7))
+    2 * (log_lik_student(0:1, 0:1, 2:3, theta = 0.7) -
+      log_lik_student(0:1, 1:2, 2:3, theta = 0.7))
   )
   expect_equal(
     dev_student(1, 0.7, 1, 5),
@@ -768,33 +893,37 @@ test_that("student log_lik", {
   )
 })
 
-test_that("student ran", {
-  set.seed(101)
-  samples <- ran_student(100000, 3, 0.5, 0.5)
-  expect_equal(mean(samples), 3.00401173552349)
-  expect_equal(var(samples), 2.47432193782075)
-  res <- dev_student(samples, 3, 0.5, 0.5, res = TRUE)
-  expect_equal(mean(res), -0.00261197674374733)
-  expect_equal(sd(res), 1.35218891518458)
+test_that("dev_student ran", {
+  withr::with_seed(101, {
+    samples <- ran_student(100000, 3, 0.5, 0.5)
+    expect_equal(mean(samples), 3.00401173552349)
+    expect_equal(var(samples), 2.47432193782075)
+    res <- dev_student(samples, 3, 0.5, 0.5, res = TRUE)
+    expect_equal(mean(res), -0.00261197674374733)
+    expect_equal(sd(res), 1.35218891518458)
+  })
 })
 
-test_that("student deviance", {
+test_that("dev_student deviance", {
   samples <- ran_student(1000, 3, 0.5, 0)
   mod <- glm(samples ~ 1, family = gaussian)
   deviance <- sum(dev_student(samples, coef(mod)[1]))
   expect_equal(deviance, deviance(mod))
 })
 
-test_that("skewnorm missing values", {
+test_that("dev_skewnorm missing values", {
   skip_if_not_installed("sn")
-  expect_identical(dev_skewnorm(logical(0), integer(0), numeric(0), numeric(0)), numeric(0))
+  expect_identical(
+    dev_skewnorm(logical(0), integer(0), numeric(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(dev_skewnorm(NA, 1, 1, 1), NA_real_)
   expect_identical(dev_skewnorm(1, NA, 1, 1), NA_real_)
   expect_identical(dev_skewnorm(1, 1, NA, 1), NA_real_)
   expect_identical(dev_skewnorm(1, 1, 1, NA), NA_real_)
 })
 
-test_that("skewnorm known values", {
+test_that("dev_skewnorm known values", {
   skip_if_not_installed("sn")
   expect_identical(dev_skewnorm(1, 1), 0)
   expect_identical(dev_skewnorm(1, 1, 1), 0)
@@ -820,52 +949,75 @@ test_that("skewnorm known values", {
   expect_equal(dev_skewnorm(0, 2, 2, 13), 176.930038215879)
 })
 
-test_that("skewnorm vectorized", {
+test_that("dev_skewnorm vectorized", {
   skip_if_not_installed("sn")
   expect_equal(dev_skewnorm(0:3, 2, 0.1, 0), c(400, 100, 0, 100))
-  expect_equal(dev_skewnorm(c(0, 1, 3, 0), 3, 0.5, 0.5), c(47.9668417319782, 22.3177579563216, 0.137683650077409, 47.9668417319782))
-  expect_equal(dev_skewnorm(0:3, 0:3, rep(1, 4), 0), rep(0, 4))
-  expect_equal(dev_skewnorm(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)), c(Inf, 1.67133656780082, 0.00816257443560442, 0.357669508605733))
-})
-
-test_that("skewnorm vectorized missing values", {
-  skip_if_not_installed("sn")
-  expect_equal(dev_skewnorm(c(NA, 1), 0:1, 0:1, 0:1), c(NA, 0.398456311678723))
-  expect_equal(dev_skewnorm(c(0, NA), 0:1, 1:2, 0:1), c(0, NA))
-  expect_equal(dev_skewnorm(c(0:1), c(NA, 1), 1:2, 0:1), c(NA, 0.398456311678724))
-  expect_equal(dev_skewnorm(c(0:1), c(0, NA), 1:2, 0:1), c(0, NA))
-  expect_equal(dev_skewnorm(c(0:1), c(0:1), c(NA, 1), 0:1), c(NA, 0.398456311678723))
-  expect_equal(dev_skewnorm(c(0:1), c(0:1), c(1, NA), 0:1), c(0, NA))
-  expect_equal(dev_skewnorm(c(0:1), c(0:1), 0:1, c(NA, 1)), c(NA, 0.398456311678723))
-  expect_equal(dev_skewnorm(c(0:1), c(0:1), 1:2, c(0, NA)), c(0, NA))
-})
-
-test_that("skewnorm res", {
-  skip_if_not_installed("sn")
-  expect_equal(dev_skewnorm(10, 0.5, 0.5), dev_skewnorm(10, 0.5, 0.5, res = TRUE)^2)
-  expect_equal(dev_skewnorm(0:1, c(0.3, 0.6), 0.5), dev_skewnorm(0:1, c(0.3, 0.6), 0.5, res = TRUE)^2)
-})
-
-test_that("skewnorm log_lik", {
-  skip_if_not_installed("sn")
   expect_equal(
-    dev_skewnorm(0:1, 1:2, 2:3, shape = 0),
-    2 * (log_lik_skewnorm(0:1, 0:1, 2:3, shape = 0) - log_lik_skewnorm(0:1, 1:2, 2:3, shape = 0))
+    dev_skewnorm(c(0, 1, 3, 0), 3, 0.5, 0.5),
+    c(47.9668417319782, 22.3177579563216, 0.137683650077409, 47.9668417319782)
+  )
+  expect_equal(dev_skewnorm(0:3, 0:3, rep(1, 4), 0), rep(0, 4))
+  expect_equal(
+    dev_skewnorm(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)),
+    c(Inf, 1.67133656780082, 0.00816257443560442, 0.357669508605733)
   )
 })
 
-test_that("skewnorm ran", {
+test_that("dev_skewnorm vectorized missing values", {
   skip_if_not_installed("sn")
-  set.seed(101)
-  samples <- ran_skewnorm(100000, 3, 0.5, 0.5)
-  expect_equal(mean(samples), 3.17851201086154)
-  expect_equal(var(samples), 0.215894351753986)
-  res <- dev_skewnorm(samples, 3, 0.5, 0.5, res = TRUE)
-  expect_equal(mean(res), 0.00818696278884169)
-  expect_equal(sd(res), 0.995441552601596)
+  expect_equal(dev_skewnorm(c(NA, 1), 0:1, 0:1, 0:1), c(NA, 0.398456311678723))
+  expect_equal(dev_skewnorm(c(0, NA), 0:1, 1:2, 0:1), c(0, NA))
+  expect_equal(
+    dev_skewnorm(c(0:1), c(NA, 1), 1:2, 0:1),
+    c(NA, 0.398456311678724)
+  )
+  expect_equal(dev_skewnorm(c(0:1), c(0, NA), 1:2, 0:1), c(0, NA))
+  expect_equal(
+    dev_skewnorm(c(0:1), c(0:1), c(NA, 1), 0:1),
+    c(NA, 0.398456311678723)
+  )
+  expect_equal(dev_skewnorm(c(0:1), c(0:1), c(1, NA), 0:1), c(0, NA))
+  expect_equal(
+    dev_skewnorm(c(0:1), c(0:1), 0:1, c(NA, 1)),
+    c(NA, 0.398456311678723)
+  )
+  expect_equal(dev_skewnorm(c(0:1), c(0:1), 1:2, c(0, NA)), c(0, NA))
 })
 
-test_that("skewnorm deviance", {
+test_that("dev_skewnorm res", {
+  skip_if_not_installed("sn")
+  expect_equal(
+    dev_skewnorm(10, 0.5, 0.5),
+    dev_skewnorm(10, 0.5, 0.5, res = TRUE)^2
+  )
+  expect_equal(
+    dev_skewnorm(0:1, c(0.3, 0.6), 0.5),
+    dev_skewnorm(0:1, c(0.3, 0.6), 0.5, res = TRUE)^2
+  )
+})
+
+test_that("dev_skewnorm log_lik", {
+  skip_if_not_installed("sn")
+  expect_equal(
+    dev_skewnorm(0:1, 1:2, 2:3, shape = 0),
+    2 * (log_lik_skewnorm(0:1, 0:1, 2:3, shape = 0) -
+      log_lik_skewnorm(0:1, 1:2, 2:3, shape = 0))
+  )
+})
+
+test_that("dev_skewnorm ran", {
+  skip_if_not_installed("sn")
+  withr::with_seed(101, {
+    samples <- ran_skewnorm(100000, 3, 0.5, 0.5)
+    expect_equal(mean(samples), 3.17851201086154)
+    expect_equal(var(samples), 0.215894351753986)
+    res <- dev_skewnorm(samples, 3, 0.5, 0.5, res = TRUE)
+    expect_equal(mean(res), 0.00818696278884169)
+    expect_equal(sd(res), 0.995441552601596)
+  })
+})
+
+test_that("dev_skewnorm deviance", {
   skip_if_not_installed("sn")
   samples <- ran_skewnorm(1000, 3, 0.5, 0)
   mod <- glm(samples ~ 1, family = gaussian)

--- a/tests/testthat/test-log-lik.R
+++ b/tests/testthat/test-log-lik.R
@@ -21,7 +21,7 @@ test_that("log_lik_beta", {
   expect_identical(log_lik_beta(1), 0)
   expect_identical(log_lik_beta(0.5), 0)
   expect_identical(log_lik_beta(0, 2, 2), -Inf)
-  expect_identical(log_lik_beta(1, 2, 2), -Inf)    
+  expect_identical(log_lik_beta(1, 2, 2), -Inf)
   expect_equal(log_lik_beta(0.5, 2, 2), 0.405465108108164)
 })
 
@@ -62,7 +62,10 @@ test_that("log_lik_pois_zi", {
   expect_identical(log_lik_pois_zi(0, 2), dpois(0, 2, log = TRUE))
   expect_identical(log_lik_pois_zi(0, 2, 1), 0)
   expect_identical(log_lik_pois_zi(1, 2, 1), -Inf)
-  expect_equal(log_lik_pois_zi(c(0, 2), 2, 0.5), c(-0.566219169516973, -2))
+  expect_equal(
+    log_lik_pois_zi(c(0, 2), 2, 0.5),
+    c(-0.566219169516973, -2)
+  )
   expect_equal(log_lik_pois_zi(3, 3.5, 0), log_lik_pois(3, 3.5))
   expect_equal(log_lik_pois_zi(3, 3.5, 0), -1.53347056374195)
   expect_equal(log_lik_pois_zi(3, 3.5, 0.1), -1.63883107939978)
@@ -79,8 +82,14 @@ test_that("log_lik_lnorm", {
 })
 
 test_that("log_lik_neg_binom", {
-  expect_identical(log_lik_neg_binom(0, 2, 1), dnbinom(0, mu = 2, size = 1, log = TRUE))
-  expect_identical(log_lik_neg_binom(0, 2, 2), dnbinom(0, size = 1 / 2, mu = 2, log = TRUE))
+  expect_identical(
+    log_lik_neg_binom(0, 2, 1),
+    dnbinom(0, mu = 2, size = 1, log = TRUE)
+  )
+  expect_identical(
+    log_lik_neg_binom(0, 2, 2),
+    dnbinom(0, size = 1 / 2, mu = 2, log = TRUE)
+  )
 })
 
 test_that("log_lik_gamma_pois", {
@@ -89,38 +98,62 @@ test_that("log_lik_gamma_pois", {
   expect_equal(log_lik_gamma_pois(0, 2, 2), -0.80471895621705)
 })
 
-test_that("gamma_pois_zi missing values", {
-  expect_identical(log_lik_gamma_pois_zi(numeric(0), numeric(0), numeric(0), numeric(0)), numeric(0))
+test_that("log_lik_gamma_pois_zi missing values", {
+  expect_identical(
+    log_lik_gamma_pois_zi(numeric(0), numeric(0), numeric(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(log_lik_gamma_pois_zi(NA, 1, 1, 0.5), NA_real_)
   expect_identical(log_lik_gamma_pois_zi(1, NA, 1, 0.5), NA_real_)
   expect_identical(log_lik_gamma_pois_zi(1, 1, NA, 0.5), NA_real_)
   expect_identical(log_lik_gamma_pois_zi(1, 1, 1, NA), NA_real_)
 })
 
-test_that("gamma_pois_zi known values", {
+test_that("log_lik_gamma_pois_zi known values", {
   expect_equal(log_lik_gamma_pois_zi(0, 3), -3)
-  expect_equal(log_lik_gamma_pois_zi(0, 3, 0.5, 0.5), -0.544727175441672)
+  expect_equal(
+    log_lik_gamma_pois_zi(0, 3, 0.5, 0.5),
+    -0.544727175441672
+  )
   expect_equal(log_lik_gamma_pois_zi(1, 2), -1.30685281944005)
   expect_equal(log_lik_gamma_pois_zi(2, 2), -1.30685281944005)
   expect_equal(log_lik_gamma_pois_zi(1, 2, 0.5), -1.38629436111989)
-  expect_equal(log_lik_gamma_pois_zi(1, 2, 0.5, 0.5), -2.07944154167984)
+  expect_equal(
+    log_lik_gamma_pois_zi(1, 2, 0.5, 0.5),
+    -2.07944154167984
+  )
 })
 
-test_that("gamma_pois_zi vectorized", {
-  expect_equal(log_lik_gamma_pois_zi(0:3, 2, 0, 0), c(-2, -1.30685281944005, -1.30685281944005, -1.71231792754822))
-  expect_equal(log_lik_gamma_pois_zi(c(0, 1, 3, 0), 3, 0.5, 0.5), c(-0.544727175441672, -2.3434070875143, -2.67191115448634, -0.544727175441672))
-  expect_equal(log_lik_gamma_pois_zi(0:3, 0:3, rep(1, 4), 0), c(0, -1.38629436111989, -1.90954250488444, -2.24934057847523))
-  expect_equal(log_lik_gamma_pois_zi(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)), c(-3, -1.90954250488444, -3.43967790223022, -Inf))
+test_that("log_lik_gamma_pois_zi vectorized", {
+  expect_equal(
+    log_lik_gamma_pois_zi(0:3, 2, 0, 0),
+    c(-2, -1.30685281944005, -1.30685281944005, -1.71231792754822)
+  )
+  expect_equal(
+    log_lik_gamma_pois_zi(c(0, 1, 3, 0), 3, 0.5, 0.5),
+    c(
+      -0.544727175441672, -2.3434070875143,
+      -2.67191115448634, -0.544727175441672
+    )
+  )
+  expect_equal(
+    log_lik_gamma_pois_zi(0:3, 0:3, rep(1, 4), 0),
+    c(0, -1.38629436111989, -1.90954250488444, -2.24934057847523)
+  )
+  expect_equal(
+    log_lik_gamma_pois_zi(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)),
+    c(-3, -1.90954250488444, -3.43967790223022, -Inf)
+  )
 })
 
-test_that("gamma missing values", {
+test_that("log_lik_gamma missing values", {
   expect_identical(log_lik_gamma(NA), NA_real_)
   expect_identical(log_lik_gamma(1, NA), NA_real_)
   expect_identical(log_lik_gamma(1, rate = NA), NA_real_)
   expect_identical(log_lik_gamma(1, shape = NA, rate = NA), NA_real_)
 })
 
-test_that("gamma known values", {
+test_that("log_lik_gamma known values", {
   expect_equal(log_lik_gamma(1, 1, 1), -1)
   expect_equal(log_lik_gamma(0, 0, 0), Inf)
   expect_equal(log_lik_gamma(1, 2, 2), -0.613705638880109)
@@ -131,21 +164,33 @@ test_that("gamma known values", {
   expect_identical(log_lik_gamma(1, 2, 5), dgamma(1, 2, 5, log = TRUE))
 })
 
-test_that("gamma vectorized", {
-  expect_equal(log_lik_gamma(4:6, 1:3, c(0.5, 1, 2)), c(-2.69314718055995, -3.3905620875659, -7.030186700424))
-  expect_equal(log_lik_gamma(1:3, c(0.5, 0.4, 0.3), 3:1), c(-3.02305879859065, -4.93530725381377, -4.86482659688575))
-  expect_equal(log_lik_gamma(seq(0, 1, length.out = 4), 1:4, seq(0, 2, length.out = 4)), c(-Inf, -2.13176472710666, -1.52992006830982, -1.01917074698827))
+test_that("log_lik_gamma vectorized", {
+  expect_equal(
+    log_lik_gamma(4:6, 1:3, c(0.5, 1, 2)),
+    c(-2.69314718055995, -3.3905620875659, -7.030186700424)
+  )
+  expect_equal(
+    log_lik_gamma(1:3, c(0.5, 0.4, 0.3), 3:1),
+    c(-3.02305879859065, -4.93530725381377, -4.86482659688575)
+  )
+  expect_equal(
+    log_lik_gamma(seq(0, 1, length.out = 4), 1:4, seq(0, 2, length.out = 4)),
+    c(-Inf, -2.13176472710666, -1.52992006830982, -1.01917074698827)
+  )
 })
 
-test_that("student missing values", {
-  expect_identical(log_lik_student(numeric(0), numeric(0), numeric(0), numeric(0)), numeric(0))
+test_that("log_lik_student missing values", {
+  expect_identical(
+    log_lik_student(numeric(0), numeric(0), numeric(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(log_lik_student(NA, 1, 1, 0.5), NA_real_)
   expect_identical(log_lik_student(1, NA, 1, 0.5), NA_real_)
   expect_identical(log_lik_student(1, 1, NA, 0.5), NA_real_)
   expect_identical(log_lik_student(1, 1, 1, NA), NA_real_)
 })
 
-test_that("student known values", {
+test_that("log_lik_student known values", {
   expect_equal(log_lik_student(0, 3), -5.41893853320467)
   expect_equal(log_lik_student(0, 3, 0), -Inf)
   expect_equal(log_lik_student(0, 3, 0, 1), -Inf)
@@ -156,30 +201,66 @@ test_that("student known values", {
   expect_equal(log_lik_student(1, 2, 0.5), -2.22579135264473)
   expect_equal(log_lik_student(1, 0, 0, 0.5), -Inf)
   expect_equal(log_lik_student(1, 2, 0.5), log_lik_norm(1, 2, 0.5))
-  expect_equal(log_lik_student(1, theta = 1 / 2), dt(1, df = 2, log = TRUE))
+  expect_equal(
+    log_lik_student(1, theta = 1 / 2),
+    dt(1, df = 2, log = TRUE)
+  )
   expect_lt(log_lik_norm(5), log_lik_student(5, theta = 1 / 5))
 })
 
-test_that("student vectorized", {
-  expect_equal(log_lik_student(0:3, 2, 0.5, 0), c(-8.22579135264473, -2.22579135264473, -0.225791352644727, -2.22579135264473))
-  expect_equal(log_lik_student(0:3, 2, 0.5, 0), log_lik_norm(0:3, 2, 0.5))
-  expect_equal(log_lik_student(c(0, 1, 3, 0), 3, 0.5, 0.5), c(-4.76323205902963, -3.6424104562843, -0.346573590279973, -4.76323205902963))
-  expect_equal(log_lik_student(0:3, 0:3, rep(1, 4), 0.5), c(-1.03972077083992, -1.03972077083992, -1.03972077083992, -1.03972077083992))
-  expect_equal(log_lik_student(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)), c(-Inf, -1.57625299452707, -1.96248581517591, -2.93648935507746))
+test_that("log_lik_student vectorized", {
+  expect_equal(
+    log_lik_student(0:3, 2, 0.5, 0),
+    c(
+      -8.22579135264473, -2.22579135264473,
+      -0.225791352644727, -2.22579135264473
+    )
+  )
+  expect_equal(
+    log_lik_student(0:3, 2, 0.5, 0),
+    log_lik_norm(0:3, 2, 0.5)
+  )
+  expect_equal(
+    log_lik_student(c(0, 1, 3, 0), 3, 0.5, 0.5),
+    c(
+      -4.76323205902963, -3.6424104562843,
+      -0.346573590279973, -4.76323205902963
+    )
+  )
+  expect_equal(
+    log_lik_student(0:3, 0:3, rep(1, 4), 0.5),
+    c(
+      -1.03972077083992, -1.03972077083992,
+      -1.03972077083992, -1.03972077083992
+    )
+  )
+  expect_equal(
+    log_lik_student(0:3, 3:0, 0:3, seq(0, 1, length.out = 4)),
+    c(-Inf, -1.57625299452707, -1.96248581517591, -2.93648935507746)
+  )
 })
 
-test_that("beta_binom missing values", {
-  expect_identical(log_lik_beta_binom(numeric(0), numeric(0), numeric(0), numeric(0)), numeric(0))
+test_that("log_lik_beta_binom missing values", {
+  expect_identical(
+    log_lik_beta_binom(numeric(0), numeric(0), numeric(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(log_lik_beta_binom(1, numeric(0)), numeric(0))
-  expect_identical(log_lik_beta_binom(1, 1, prob = numeric(0)), numeric(0))
-  expect_identical(log_lik_beta_binom(1, 1, theta = numeric(0)), numeric(0))
+  expect_identical(
+    log_lik_beta_binom(1, 1, prob = numeric(0)),
+    numeric(0)
+  )
+  expect_identical(
+    log_lik_beta_binom(1, 1, theta = numeric(0)),
+    numeric(0)
+  )
   expect_identical(log_lik_beta_binom(NA, 1, 1, 0.5), NA_real_)
   expect_identical(log_lik_beta_binom(1, NA, 1, 0.5), NA_real_)
   expect_identical(log_lik_beta_binom(1, 1, NA, 0.5), NA_real_)
   expect_identical(log_lik_beta_binom(1, 1, 1, NA), NA_real_)
 })
 
-test_that("beta_binom known values", {
+test_that("log_lik_beta_binom known values", {
   expect_equal(log_lik_beta_binom(0, 3), -2.07944154167984)
   expect_equal(log_lik_beta_binom(0, 3, 0), 0)
   expect_equal(log_lik_beta_binom(0, 3, 1), -Inf)
@@ -193,8 +274,14 @@ test_that("beta_binom known values", {
   expect_equal(log_lik_beta_binom(1, 2, 0.5), -0.693147180559945)
   expect_equal(log_lik_beta_binom(10, 2, 0.5, 0.1), -Inf)
   expect_equal(log_lik_beta_binom(10, 2, 0.5, -0.1), NaN)
-  expect_equal(log_lik_beta_binom(1, 2, 0.5), log_lik_binom(1, 2, 0.5))
-  expect_equal(log_lik_beta_binom(1, 2, 0.2), dbinom(1, 2, 0.2, log = TRUE))
+  expect_equal(
+    log_lik_beta_binom(1, 2, 0.5),
+    log_lik_binom(1, 2, 0.5)
+  )
+  expect_equal(
+    log_lik_beta_binom(1, 2, 0.2),
+    dbinom(1, 2, 0.2, log = TRUE)
+  )
 })
 
 test_that("beta binomial deviance function is memoized", {
@@ -223,7 +310,7 @@ test_that("lgamma_size_x produces expected outputs", {
   )
 })
 
-test_that("beta_binom memoized function gives same outputs as non-memoized function", {
+test_that("log_lik_beta_binom memoized function gives same outputs as non-memoized function", {
   skip_if_not_installed("memoise")
   expect_equal(
     log_lik_beta_binom(1:100, 200, 0.5, 0.1, memoize = FALSE),
@@ -235,15 +322,33 @@ test_that("beta_binom memoized function gives same outputs as non-memoized funct
   )
 })
 
-test_that("beta_binom vectorized", {
-  expect_equal(log_lik_beta_binom(0:3, 2, 0.5, 0), c(-1.38629436111989, -0.693147180559945, -1.38629436111989, -Inf))
-  expect_equal(log_lik_beta_binom(0:3, 2, 0.5, 0), log_lik_binom(0:3, 2, 0.5))
-  expect_equal(log_lik_beta_binom(c(0, 1, 3, 4, 5), 3, 0.5, 0.5), c(-1.6094379124341, -1.20397280432594, -1.6094379124341, -Inf, -Inf))
-  expect_equal(log_lik_beta_binom(0:3, 5:8, seq(0, 1, length.out = 4), 0.5), c(0, -1.47834815081045, -2.50875218945204, -Inf))
-  expect_equal(log_lik_beta_binom(0:3, 3:0, seq(0, 1, length.out = 4), 0.5), c(0, -1.03407376753054, -Inf, -Inf))
+test_that("log_lik_beta_binom vectorized", {
+  expect_equal(
+    log_lik_beta_binom(0:3, 2, 0.5, 0),
+    c(-1.38629436111989, -0.693147180559945, -1.38629436111989, -Inf)
+  )
+  expect_equal(
+    log_lik_beta_binom(0:3, 2, 0.5, 0),
+    log_lik_binom(0:3, 2, 0.5)
+  )
+  expect_equal(
+    log_lik_beta_binom(c(0, 1, 3, 4, 5), 3, 0.5, 0.5),
+    c(
+      -1.6094379124341, -1.20397280432594,
+      -1.6094379124341, -Inf, -Inf
+    )
+  )
+  expect_equal(
+    log_lik_beta_binom(0:3, 5:8, seq(0, 1, length.out = 4), 0.5),
+    c(0, -1.47834815081045, -2.50875218945204, -Inf)
+  )
+  expect_equal(
+    log_lik_beta_binom(0:3, 3:0, seq(0, 1, length.out = 4), 0.5),
+    c(0, -1.03407376753054, -Inf, -Inf)
+  )
 })
 
-test_that("beta_binom log_lik", {
+test_that("log_lik_beta_binom log_lik", {
   withr::with_seed(
     101,
     samples <- ran_beta_binom(100, size = 50, prob = 0.1, theta = 1)
@@ -258,19 +363,28 @@ test_that("beta_binom log_lik", {
   )
 })
 
-test_that("skewnorm missing values", {
+test_that("log_lik_skewnorm missing values", {
   skip_if_not_installed("sn")
-  expect_identical(log_lik_skewnorm(numeric(0), numeric(0), numeric(0), numeric(0)), numeric(0))
+  expect_identical(
+    log_lik_skewnorm(numeric(0), numeric(0), numeric(0), numeric(0)),
+    numeric(0)
+  )
   expect_identical(log_lik_skewnorm(1, numeric(0)), numeric(0))
-  expect_identical(log_lik_skewnorm(1, 1, sd = numeric(0)), numeric(0))
-  expect_identical(log_lik_skewnorm(1, 1, shape = numeric(0)), numeric(0))
+  expect_identical(
+    log_lik_skewnorm(1, 1, sd = numeric(0)),
+    numeric(0)
+  )
+  expect_identical(
+    log_lik_skewnorm(1, 1, shape = numeric(0)),
+    numeric(0)
+  )
   expect_identical(log_lik_skewnorm(NA, 1, 1, 0.5), NA_real_)
   expect_identical(log_lik_skewnorm(1, NA, 1, 0.5), NA_real_)
   expect_identical(log_lik_skewnorm(1, 1, NA, 0.5), NA_real_)
   expect_identical(log_lik_skewnorm(1, 1, 1, NA), NA_real_)
 })
 
-test_that("skewnorm known values", {
+test_that("log_lik_skewnorm known values", {
   skip_if_not_installed("sn")
   expect_equal(log_lik_skewnorm(0.5, 3), -4.04393853320467)
   expect_equal(log_lik_skewnorm(0.5, 3, 0), -Inf)
@@ -283,15 +397,24 @@ test_that("skewnorm known values", {
   expect_equal(log_lik_skewnorm(1, 2, 0.2, -1), -11.1163537268622)
   expect_equal(log_lik_skewnorm(2, 2, 0.2, 10), 0.690499379229428)
   expect_equal(log_lik_skewnorm(1, 2, 0.5, -10), -1.53264417208478)
-  expect_equal(log_lik_skewnorm(1, 2, 0.5, 0), log_lik_norm(1, 2, 0.5))
-  expect_equal(log_lik_skewnorm(1, 2, 0.2), dnorm(1, 2, 0.2, log = TRUE))
+  expect_equal(
+    log_lik_skewnorm(1, 2, 0.5, 0),
+    log_lik_norm(1, 2, 0.5)
+  )
+  expect_equal(
+    log_lik_skewnorm(1, 2, 0.2),
+    dnorm(1, 2, 0.2, log = TRUE)
+  )
 })
 
-test_that("skewnorm vectorized", {
+test_that("log_lik_skewnorm vectorized", {
   skip_if_not_installed("sn")
   expect_equal(
     log_lik_skewnorm(0:3, 2, 0.5, 0),
-    c(-8.22579135264473, -2.22579135264473, -0.225791352644727, -2.22579135264473)
+    c(
+      -8.22579135264473, -2.22579135264473,
+      -0.225791352644727, -2.22579135264473
+    )
   )
   expect_equal(
     log_lik_skewnorm(0:3, 2, 0.5, 0),
@@ -314,7 +437,10 @@ test_that("skewnorm vectorized", {
   )
   expect_equal(
     log_lik_skewnorm(0:3, 3:0, 0.2, -1:2),
-    c(-111.116353440211, -11.8095006207706, -11.1163537268622, -111.116353440211)
+    c(
+      -111.116353440211, -11.8095006207706,
+      -11.1163537268622, -111.116353440211
+    )
   )
 })
 

--- a/tests/testthat/test-ran.R
+++ b/tests/testthat/test-ran.R
@@ -2,168 +2,210 @@ test_that("ran_pois", {
   expect_error(ran_pois(NA_integer_))
   expect_error(ran_pois(integer(0)))
   expect_identical(ran_pois(0L), integer(0))
-  set.seed(101)
-  expect_identical(ran_pois(), 1L)
-  expect_identical(ran_pois(2), c(0L, 1L))
-  expect_identical(ran_pois(2, 10), c(11L, 8L))
-  expect_identical(ran_pois(2, c(0.1, 100)), c(0L, 103L))
-  expect_identical(ran_pois(1, c(0.1, 100)), 0L)
+  withr::with_seed(101, {
+    expect_identical(ran_pois(), 1L)
+    expect_identical(ran_pois(2), c(0L, 1L))
+    expect_identical(ran_pois(2, 10), c(11L, 8L))
+    expect_identical(ran_pois(2, c(0.1, 100)), c(0L, 103L))
+    expect_identical(ran_pois(1, c(0.1, 100)), 0L)
+  })
 })
 
 test_that("ran_pois_zi", {
   expect_error(ran_pois_zi(NA_integer_))
   expect_error(ran_pois_zi(integer(0)))
   expect_identical(ran_pois_zi(0L), integer(0))
-  set.seed(101)
-  expect_identical(ran_pois_zi(), 1L)
-  expect_identical(ran_pois_zi(2), c(0L, 1L))
-  expect_identical(ran_pois_zi(2, 10), c(11L, 8L))
-  expect_identical(ran_pois_zi(2, c(0.1, 100)), c(0L, 103L))
-  expect_identical(ran_pois_zi(1, c(0.1, 100)), 0L)
-  set.seed(101)
-  expect_identical(ran_pois_zi(10, 10, 0.5), c(0L, 11L, 7L, 8L, 0L, 0L, 0L, 10L, 0L, 0L))
+  withr::with_seed(101, {
+    expect_identical(ran_pois_zi(), 1L)
+    expect_identical(ran_pois_zi(2), c(0L, 1L))
+    expect_identical(ran_pois_zi(2, 10), c(11L, 8L))
+    expect_identical(ran_pois_zi(2, c(0.1, 100)), c(0L, 103L))
+    expect_identical(ran_pois_zi(1, c(0.1, 100)), 0L)
+  })
+  withr::with_seed(101, {
+    expect_identical(
+      ran_pois_zi(10, 10, 0.5),
+      c(0L, 11L, 7L, 8L, 0L, 0L, 0L, 10L, 0L, 0L)
+    )
+  })
 })
 
 test_that("ran_norm", {
   expect_error(ran_norm(NA_integer_))
   expect_error(ran_norm(integer(0)))
   expect_identical(ran_norm(0L), numeric(0))
-  set.seed(101)
-  expect_equal(ran_norm(), -0.326036490515386)
-  expect_equal(ran_norm(2), c(0.552461855419139, -0.67494384395583))
-  expect_equal(ran_norm(2, 10), c(10.2143594590434, 10.3107692173136))
-  expect_equal(ran_norm(2, c(0.1, 100)), c(1.2739662875627, 100.618789855626))
-  expect_equal(ran_norm(1, c(0.1, 100)), -0.0127343147542145)
+  withr::with_seed(101, {
+    expect_equal(ran_norm(), -0.326036490515386)
+    expect_equal(ran_norm(2), c(0.552461855419139, -0.67494384395583))
+    expect_equal(ran_norm(2, 10), c(10.2143594590434, 10.3107692173136))
+    expect_equal(ran_norm(2, c(0.1, 100)), c(1.2739662875627, 100.618789855626))
+    expect_equal(ran_norm(1, c(0.1, 100)), -0.0127343147542145)
+  })
 })
 
 test_that("ran_lnorm", {
   expect_error(ran_lnorm(NA_integer_))
   expect_error(ran_lnorm(integer(0)))
   expect_identical(ran_lnorm(0L), numeric(0))
-  set.seed(101)
-  expect_equal(ran_lnorm(), 0.721778848868975)
-  expect_equal(ran_lnorm(2), c(1.73752529290614, 0.509185013620822))
-  expect_equal(ran_lnorm(2, 10), c(27292.2882352846, 30054.546228237))
-  expect_equal(ran_lnorm(2, c(0.1, 100)), c(3.57500397331701, 4.99097288094876e+43))
-  expect_equal(ran_lnorm(1, c(0.1, 100)), 0.987346423552865)
+  withr::with_seed(101, {
+    expect_equal(ran_lnorm(), 0.721778848868975)
+    expect_equal(ran_lnorm(2), c(1.73752529290614, 0.509185013620822))
+    expect_equal(ran_lnorm(2, 10), c(27292.2882352846, 30054.546228237))
+    expect_equal(
+      ran_lnorm(2, c(0.1, 100)),
+      c(3.57500397331701, 4.99097288094876e+43)
+    )
+    expect_equal(ran_lnorm(1, c(0.1, 100)), 0.987346423552865)
+  })
 })
 
 test_that("ran_binom", {
   expect_error(ran_binom(NA_integer_))
   expect_error(ran_binom(integer(0)))
   expect_identical(ran_binom(0L), integer(0))
-  set.seed(101)
-  expect_identical(ran_binom(), 0L)
-  expect_identical(ran_binom(2), c(0L, 1L))
-  expect_identical(ran_binom(2, 10), c(6L, 4L))
-  expect_identical(ran_binom(2, c(2, 100)), c(1L, 47L))
-  expect_identical(ran_binom(1, c(2, 100)), 1L)
-  expect_identical(ran_binom(1, 100, 0.1), 10L)
+  withr::with_seed(101, {
+    expect_identical(ran_binom(), 0L)
+    expect_identical(ran_binom(2), c(0L, 1L))
+    expect_identical(ran_binom(2, 10), c(6L, 4L))
+    expect_identical(ran_binom(2, c(2, 100)), c(1L, 47L))
+    expect_identical(ran_binom(1, c(2, 100)), 1L)
+    expect_identical(ran_binom(1, 100, 0.1), 10L)
+  })
 })
 
 test_that("ran_bern", {
   expect_error(ran_bern(NA_integer_))
   expect_error(ran_bern(integer(0)))
   expect_identical(ran_bern(0L), integer(0))
-  set.seed(101)
-  expect_identical(ran_bern(), 0L)
-  expect_identical(ran_bern(2), c(0L, 1L))
-  expect_identical(ran_bern(2, c(0.1, 1)), c(0L, 1L))
-  expect_identical(ran_bern(1, c(0.1, 1)), 0L)
+  withr::with_seed(101, {
+    expect_identical(ran_bern(), 0L)
+    expect_identical(ran_bern(2), c(0L, 1L))
+    expect_identical(ran_bern(2, c(0.1, 1)), c(0L, 1L))
+    expect_identical(ran_bern(1, c(0.1, 1)), 0L)
+  })
 })
 
 test_that("ran_gamma_pois", {
   expect_error(ran_gamma_pois(NA_integer_))
   expect_error(ran_gamma_pois(integer(0)))
   expect_identical(ran_gamma_pois(0L), integer(0))
-  set.seed(101)
-  expect_identical(ran_gamma_pois(), 1L)
-  expect_identical(ran_gamma_pois(2), c(0L, 2L))
-  expect_identical(ran_gamma_pois(2, 10), c(14L, 7L))
-  expect_identical(ran_gamma_pois(2, c(0.1, 100)), c(0L, 108L))
-  expect_identical(ran_gamma_pois(1, c(0.1, 100)), 0L)
-  set.seed(101)
-  expect_identical(ran_gamma_pois(theta = 10), 0L)
-  expect_identical(ran_gamma_pois(2, theta = 10), c(1L, 2L))
-  expect_identical(ran_gamma_pois(2, 10, theta = 10), c(0L, 0L))
-  expect_identical(ran_gamma_pois(2, 10, theta = 10), c(7L, 13L))
-  expect_identical(ran_gamma_pois(2, c(0.1, 100), theta = 1), c(0L, 12L))
-  expect_identical(ran_gamma_pois(2, c(0.1, 100), theta = 1), c(0L, 117L))
-  expect_identical(ran_gamma_pois(1, c(0.1, 100), theta = 1), 0L)
+  withr::with_seed(101, {
+    expect_identical(ran_gamma_pois(), 1L)
+    expect_identical(ran_gamma_pois(2), c(0L, 2L))
+    expect_identical(ran_gamma_pois(2, 10), c(14L, 7L))
+    expect_identical(ran_gamma_pois(2, c(0.1, 100)), c(0L, 108L))
+    expect_identical(ran_gamma_pois(1, c(0.1, 100)), 0L)
+  })
+  withr::with_seed(101, {
+    expect_identical(ran_gamma_pois(theta = 10), 0L)
+    expect_identical(ran_gamma_pois(2, theta = 10), c(1L, 2L))
+    expect_identical(ran_gamma_pois(2, 10, theta = 10), c(0L, 0L))
+    expect_identical(ran_gamma_pois(2, 10, theta = 10), c(7L, 13L))
+    expect_identical(ran_gamma_pois(2, c(0.1, 100), theta = 1), c(0L, 12L))
+    expect_identical(ran_gamma_pois(2, c(0.1, 100), theta = 1), c(0L, 117L))
+    expect_identical(ran_gamma_pois(1, c(0.1, 100), theta = 1), 0L)
+  })
 })
 
 test_that("ran_neg_binom", {
   expect_error(ran_neg_binom(NA_integer_))
   expect_error(ran_neg_binom(integer(0)))
   expect_identical(ran_neg_binom(0L), integer(0))
-  set.seed(101)
-  expect_identical(ran_neg_binom(), 1L)
-  expect_identical(ran_neg_binom(2), c(0L, 2L))
-  expect_identical(ran_neg_binom(2, 10), c(14L, 7L))
-  expect_identical(ran_neg_binom(2, c(0.1, 100)), c(0L, 108L))
-  expect_identical(ran_neg_binom(1, c(0.1, 100)), 0L)
-  set.seed(101)
-  expect_identical(ran_neg_binom(theta = 10), 0L)
-  expect_identical(ran_neg_binom(2, theta = 10), c(1L, 2L))
-  expect_identical(ran_neg_binom(2, 10, theta = 10), c(0L, 0L))
-  expect_identical(ran_neg_binom(2, 10, theta = 10), c(7L, 13L))
-  expect_identical(ran_neg_binom(2, c(0.1, 100), theta = 1), c(0L, 12L))
-  expect_identical(ran_neg_binom(2, c(0.1, 100), theta = 1), c(0L, 117L))
-  expect_identical(ran_neg_binom(1, c(0.1, 100), theta = 1), 0L)
+  withr::with_seed(101, {
+    expect_identical(ran_neg_binom(), 1L)
+    expect_identical(ran_neg_binom(2), c(0L, 2L))
+    expect_identical(ran_neg_binom(2, 10), c(14L, 7L))
+    expect_identical(ran_neg_binom(2, c(0.1, 100)), c(0L, 108L))
+    expect_identical(ran_neg_binom(1, c(0.1, 100)), 0L)
+  })
+  withr::with_seed(101, {
+    expect_identical(ran_neg_binom(theta = 10), 0L)
+    expect_identical(ran_neg_binom(2, theta = 10), c(1L, 2L))
+    expect_identical(ran_neg_binom(2, 10, theta = 10), c(0L, 0L))
+    expect_identical(ran_neg_binom(2, 10, theta = 10), c(7L, 13L))
+    expect_identical(ran_neg_binom(2, c(0.1, 100), theta = 1), c(0L, 12L))
+    expect_identical(ran_neg_binom(2, c(0.1, 100), theta = 1), c(0L, 117L))
+    expect_identical(ran_neg_binom(1, c(0.1, 100), theta = 1), 0L)
+  })
 })
 
 test_that("ran_gamma_pois_zi", {
   expect_error(ran_gamma_pois_zi(NA_integer_))
   expect_error(ran_gamma_pois_zi(integer(0)))
   expect_identical(ran_gamma_pois_zi(0L), integer(0))
-  set.seed(101)
-  expect_identical(ran_gamma_pois_zi(), 1L)
-  expect_identical(ran_gamma_pois_zi(2), c(0L, 2L))
-  expect_identical(ran_gamma_pois_zi(2, 10), c(14L, 7L))
-  expect_identical(ran_gamma_pois_zi(2, c(0.1, 100)), c(0L, 108L))
-  expect_identical(ran_gamma_pois_zi(1, c(0.1, 100)), 0L)
-  set.seed(101)
-  expect_identical(ran_gamma_pois_zi(prob = 0.5), 0L)
-  expect_identical(ran_gamma_pois_zi(2, prob = 0.5), c(1L, 1L))
-  expect_identical(ran_gamma_pois_zi(2, 10, prob = 0.5), c(7L, 0L))
-  expect_identical(ran_gamma_pois_zi(2, c(0.1, 100), prob = 0.5), c(0L, 100L))
-  expect_identical(ran_gamma_pois_zi(1, c(0.1, 100), prob = 0.5), 0L)
-  set.seed(101)
-  expect_identical(ran_gamma_pois_zi(theta = 10), 0L)
-  expect_identical(ran_gamma_pois_zi(2, theta = 10), c(1L, 2L))
-  expect_identical(ran_gamma_pois_zi(2, 10, theta = 10), c(0L, 0L))
-  expect_identical(ran_gamma_pois_zi(2, 10, theta = 10), c(7L, 13L))
-  expect_identical(ran_gamma_pois_zi(2, c(0.1, 100), theta = 1), c(0L, 12L))
-  expect_identical(ran_gamma_pois_zi(2, c(0.1, 100), theta = 1), c(0L, 117L))
-  expect_identical(ran_gamma_pois_zi(1, c(0.1, 100), theta = 1), 0L)
-  set.seed(101)
-  expect_identical(ran_gamma_pois_zi(theta = 10, prob = 0.5), 0L)
-  expect_identical(ran_gamma_pois_zi(2, theta = 10, prob = 0.5), c(0L, 0L))
-  expect_identical(ran_gamma_pois_zi(2, 10, theta = 10, prob = 0.5), c(9L, 0L))
-  expect_identical(ran_gamma_pois_zi(2, 10, theta = 10, prob = 0.5), c(0L, 0L))
-  expect_identical(ran_gamma_pois_zi(2, c(0.1, 100), theta = 1, prob = 0.5), c(0L, 0L))
-  expect_identical(ran_gamma_pois_zi(2, c(0.1, 100), theta = 1, prob = 0.5), c(0L, 0L))
-  expect_identical(ran_gamma_pois_zi(1, c(0.1, 100), theta = 1, prob = 0.5), 0L)
+  withr::with_seed(101, {
+    expect_identical(ran_gamma_pois_zi(), 1L)
+    expect_identical(ran_gamma_pois_zi(2), c(0L, 2L))
+    expect_identical(ran_gamma_pois_zi(2, 10), c(14L, 7L))
+    expect_identical(ran_gamma_pois_zi(2, c(0.1, 100)), c(0L, 108L))
+    expect_identical(ran_gamma_pois_zi(1, c(0.1, 100)), 0L)
+  })
+  withr::with_seed(101, {
+    expect_identical(ran_gamma_pois_zi(prob = 0.5), 0L)
+    expect_identical(ran_gamma_pois_zi(2, prob = 0.5), c(1L, 1L))
+    expect_identical(ran_gamma_pois_zi(2, 10, prob = 0.5), c(7L, 0L))
+    expect_identical(ran_gamma_pois_zi(2, c(0.1, 100), prob = 0.5), c(0L, 100L))
+    expect_identical(ran_gamma_pois_zi(1, c(0.1, 100), prob = 0.5), 0L)
+  })
+  withr::with_seed(101, {
+    expect_identical(ran_gamma_pois_zi(theta = 10), 0L)
+    expect_identical(ran_gamma_pois_zi(2, theta = 10), c(1L, 2L))
+    expect_identical(ran_gamma_pois_zi(2, 10, theta = 10), c(0L, 0L))
+    expect_identical(ran_gamma_pois_zi(2, 10, theta = 10), c(7L, 13L))
+    expect_identical(ran_gamma_pois_zi(2, c(0.1, 100), theta = 1), c(0L, 12L))
+    expect_identical(ran_gamma_pois_zi(2, c(0.1, 100), theta = 1), c(0L, 117L))
+    expect_identical(ran_gamma_pois_zi(1, c(0.1, 100), theta = 1), 0L)
+  })
+  withr::with_seed(101, {
+    expect_identical(ran_gamma_pois_zi(theta = 10, prob = 0.5), 0L)
+    expect_identical(ran_gamma_pois_zi(2, theta = 10, prob = 0.5), c(0L, 0L))
+    expect_identical(
+      ran_gamma_pois_zi(2, 10, theta = 10, prob = 0.5),
+      c(9L, 0L)
+    )
+    expect_identical(
+      ran_gamma_pois_zi(2, 10, theta = 10, prob = 0.5),
+      c(0L, 0L)
+    )
+    expect_identical(
+      ran_gamma_pois_zi(2, c(0.1, 100), theta = 1, prob = 0.5),
+      c(0L, 0L)
+    )
+    expect_identical(
+      ran_gamma_pois_zi(2, c(0.1, 100), theta = 1, prob = 0.5),
+      c(0L, 0L)
+    )
+    expect_identical(
+      ran_gamma_pois_zi(1, c(0.1, 100), theta = 1, prob = 0.5),
+      0L
+    )
+  })
 })
 
 test_that("ran_gamma", {
   expect_error(ran_gamma(NA_integer_))
   expect_error(ran_gamma(integer(0)))
   expect_identical(ran_gamma(0L), numeric(0))
-  set.seed(101)
-  expect_equal(ran_gamma(), 0.296032334929205)
-  expect_equal(ran_gamma(2), c(0.828447196595941, 0.198011979729563))
-  set.seed(101)
-  expect_equal(ran_gamma(shape = 2), 1.12726342864167)
-  expect_equal(ran_gamma(rate = 2), 0.41422359829797)
-  expect_equal(ran_gamma(shape = 2, rate = 2), 0.463321963301684)
-  expect_equal(ran_gamma(shape = 0.5), 1.25656793027554)
-  expect_equal(ran_gamma(rate = 0.5), 2.06655144879794)
-  expect_equal(ran_gamma(shape = 0.5, rate = 0.5), 1.88702952622222)
-  set.seed(101)
-  expect_equal(ran_gamma(1, shape = c(1, 2), rate = 0.5), 0.592064669858409)
-  expect_equal(ran_gamma(1, rate = c(1, 2)), 0.828447196595941)
-  expect_equal(ran_gamma(2, shape = c(1, 2), rate = c(1, 2)), c(0.198011979729563, 0.95237869084932))
+  withr::with_seed(101, {
+    expect_equal(ran_gamma(), 0.296032334929205)
+    expect_equal(ran_gamma(2), c(0.828447196595941, 0.198011979729563))
+  })
+  withr::with_seed(101, {
+    expect_equal(ran_gamma(shape = 2), 1.12726342864167)
+    expect_equal(ran_gamma(rate = 2), 0.41422359829797)
+    expect_equal(ran_gamma(shape = 2, rate = 2), 0.463321963301684)
+    expect_equal(ran_gamma(shape = 0.5), 1.25656793027554)
+    expect_equal(ran_gamma(rate = 0.5), 2.06655144879794)
+    expect_equal(ran_gamma(shape = 0.5, rate = 0.5), 1.88702952622222)
+  })
+  withr::with_seed(101, {
+    expect_equal(ran_gamma(1, shape = c(1, 2), rate = 0.5), 0.592064669858409)
+    expect_equal(ran_gamma(1, rate = c(1, 2)), 0.828447196595941)
+    expect_equal(
+      ran_gamma(2, shape = c(1, 2), rate = c(1, 2)),
+      c(0.198011979729563, 0.95237869084932)
+    )
+  })
 })
 
 test_that("ran_student", {
@@ -172,73 +214,138 @@ test_that("ran_student", {
   expect_error(ran_student(-1))
   expect_error(ran_student(0.1))
   expect_identical(ran_student(0L), numeric(0))
-  set.seed(101)
-  expect_equal(ran_student(), -0.326036490515386)
-  expect_equal(ran_student(2), c(0.552461855419139, -0.67494384395583))
-  expect_equal(ran_student(2, mean = 10), c(10.2143594590434, 10.3107692173136))
-  expect_equal(ran_student(2, mean = c(0.1, 100)), c(1.2739662875627, 100.618789855626))
-  expect_equal(ran_student(2, sd = 10), c(-1.12734314754215, 9.17028289512712))
-  expect_equal(ran_student(1, sd = c(0.1, 100)), -0.0223259364627263)
-  expect_equal(ran_student(1, 5, 0), 5L)
-  expect_equal(ran_student(1, 5, 0, 1), 5L)
-  expect_equal(ran_student(2, mean = c(5, 10), sd = c(0.1, 1)), c(4.85331803058365, 9.7633166213971))
-  expect_equal(ran_student(1, mean = c(5, 10), sd = c(0.1, 1)), 4.98066620350025)
-  set.seed(101)
-  expect_equal(ran_student(theta = 0.5), -0.33156105737203)
-  expect_equal(ran_student(2, theta = 0.5), c(-0.828877594163717, 0.240144994036107))
-  expect_equal(ran_student(2, 10, theta = 0.5), c(10.950902377826, 9.64745806982169))
-  expect_equal(ran_student(2, c(0.1, 100), theta = 0.5), c(-0.585038332110831, 101.180666799288))
-  expect_equal(ran_student(1, c(0.1, 100), theta = 0.5), 2.36756946562059)
-  set.seed(101)
-  expect_equal(ran_student(theta = 10), -1.87474739594541)
-  expect_equal(ran_student(2, theta = 10), c(-26.8550547217203, 0.208423313901581))
-  expect_equal(ran_student(2, 10, theta = 10), c(312.416238182549, 1232.50541097839))
-  expect_equal(ran_student(2, c(0.1, 100), theta = 1), c(1.57371753266519, 111.974370801549))
-  expect_equal(ran_student(2, c(0.1, 100), theta = 1), c(-0.233907776839805, 74.8346231062475))
-  expect_equal(ran_student(1, c(0.1, 100), theta = 1), 1.17304786153918)
-  set.seed(101)
-  expect_equal(ran_student(theta = 0.1), -0.304076815655304)
-  expect_equal(ran_student(2, theta = 0.1), c(-0.677235928466201, 0.256581693475524))
-  expect_equal(ran_student(2, 10, theta = 0.1), c(10.6700666098513, 8.63003697321142))
-  expect_equal(ran_student(2, 10, 0.1, theta = 0.1), c(9.93731209896207, 9.83624845227821))
-  expect_equal(ran_student(2, c(0.1, 100), 10, theta = 0.1), c(-6.27604275569631, 83.3203568426077))
-  expect_equal(ran_student(2, c(0.1, 100), c(0.1, 100), theta = 0.1), c(0.0828946276667616, -31.2764527374883))
+  withr::with_seed(101, {
+    expect_equal(ran_student(), -0.326036490515386)
+    expect_equal(ran_student(2), c(0.552461855419139, -0.67494384395583))
+    expect_equal(
+      ran_student(2, mean = 10),
+      c(10.2143594590434, 10.3107692173136)
+    )
+    expect_equal(
+      ran_student(2, mean = c(0.1, 100)),
+      c(1.2739662875627, 100.618789855626)
+    )
+    expect_equal(
+      ran_student(2, sd = 10),
+      c(-1.12734314754215, 9.17028289512712)
+    )
+    expect_equal(ran_student(1, sd = c(0.1, 100)), -0.0223259364627263)
+    expect_equal(ran_student(1, 5, 0), 5L)
+    expect_equal(ran_student(1, 5, 0, 1), 5L)
+    expect_equal(
+      ran_student(2, mean = c(5, 10), sd = c(0.1, 1)),
+      c(4.85331803058365, 9.7633166213971)
+    )
+    expect_equal(
+      ran_student(1, mean = c(5, 10), sd = c(0.1, 1)),
+      4.98066620350025
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(ran_student(theta = 0.5), -0.33156105737203)
+    expect_equal(
+      ran_student(2, theta = 0.5),
+      c(-0.828877594163717, 0.240144994036107)
+    )
+    expect_equal(
+      ran_student(2, 10, theta = 0.5),
+      c(10.950902377826, 9.64745806982169)
+    )
+    expect_equal(
+      ran_student(2, c(0.1, 100), theta = 0.5),
+      c(-0.585038332110831, 101.180666799288)
+    )
+    expect_equal(ran_student(1, c(0.1, 100), theta = 0.5), 2.36756946562059)
+  })
+  withr::with_seed(101, {
+    expect_equal(ran_student(theta = 10), -1.87474739594541)
+    expect_equal(
+      ran_student(2, theta = 10),
+      c(-26.8550547217203, 0.208423313901581)
+    )
+    expect_equal(
+      ran_student(2, 10, theta = 10),
+      c(312.416238182549, 1232.50541097839)
+    )
+    expect_equal(
+      ran_student(2, c(0.1, 100), theta = 1),
+      c(1.57371753266519, 111.974370801549)
+    )
+    expect_equal(
+      ran_student(2, c(0.1, 100), theta = 1),
+      c(-0.233907776839805, 74.8346231062475)
+    )
+    expect_equal(ran_student(1, c(0.1, 100), theta = 1), 1.17304786153918)
+  })
+  withr::with_seed(101, {
+    expect_equal(ran_student(theta = 0.1), -0.304076815655304)
+    expect_equal(
+      ran_student(2, theta = 0.1),
+      c(-0.677235928466201, 0.256581693475524)
+    )
+    expect_equal(
+      ran_student(2, 10, theta = 0.1),
+      c(10.6700666098513, 8.63003697321142)
+    )
+    expect_equal(
+      ran_student(2, 10, 0.1, theta = 0.1),
+      c(9.93731209896207, 9.83624845227821)
+    )
+    expect_equal(
+      ran_student(2, c(0.1, 100), 10, theta = 0.1),
+      c(-6.27604275569631, 83.3203568426077)
+    )
+    expect_equal(
+      ran_student(2, c(0.1, 100), c(0.1, 100), theta = 0.1),
+      c(0.0828946276667616, -31.2764527374883)
+    )
+  })
 })
 
 test_that("ran_beta_binom", {
   expect_error(ran_beta_binom(NA_integer_))
   expect_error(ran_beta_binom(integer(0)))
   expect_identical(ran_beta_binom(0L), integer(0))
-  set.seed(101)
-  expect_identical(ran_beta_binom(), 0L)
-  expect_identical(ran_beta_binom(2), c(0L, 1L))
-  expect_identical(ran_beta_binom(2, 10), c(6L, 4L))
-  expect_identical(ran_beta_binom(2, c(5, 10)), c(2L, 5L))
-  expect_identical(ran_beta_binom(1, c(5, 10)), 2L)
-  set.seed(101)
-  expect_identical(ran_beta_binom(prob = 0.2), 0L)
-  expect_identical(ran_beta_binom(2, prob = 0.2), c(0L, 0L))
-  expect_identical(ran_beta_binom(2, 10, prob = 0.2), c(2L, 1L))
-  expect_identical(ran_beta_binom(2, c(5, 10), prob = 0.2), c(0L, 2L))
-  expect_identical(ran_beta_binom(1, c(5, 10), prob = 0.2), 1L)
-  expect_identical(ran_beta_binom(1, 0, prob = 0.2), 0L)
-  expect_identical(ran_beta_binom(1, 0, prob = 0.9), 0L)
-  set.seed(101)
-  expect_identical(ran_beta_binom(theta = 10), 1L)
-  expect_identical(ran_beta_binom(2, theta = 10), c(0L, 1L))
-  expect_identical(ran_beta_binom(2, 10, theta = 10), c(0L, 10L))
-  expect_identical(ran_beta_binom(2, 10, theta = 10), c(0L, 0L))
-  expect_identical(ran_beta_binom(2, c(10, 100), theta = 1), c(2L, 70L))
-  expect_identical(ran_beta_binom(2, c(10, 100), theta = 1), c(10L, 54L))
-  expect_identical(ran_beta_binom(1, c(10, 100), theta = 1), 6L)
-  set.seed(101)
-  expect_identical(ran_beta_binom(theta = 0.5, prob = 0.2), 1L)
-  expect_identical(ran_beta_binom(2, theta = 0.5, prob = 0.2), c(0L, 1L))
-  expect_identical(ran_beta_binom(2, 10, theta = 0.5, prob = 0.2), c(4L, 1L))
-  expect_identical(ran_beta_binom(2, 10, theta = 0.5, prob = 0.2), c(0L, 5L))
-  expect_identical(ran_beta_binom(2, c(10, 100), theta = 1, prob = 0.2), c(0L, 0L))
-  expect_identical(ran_beta_binom(2, c(10, 100), theta = 1, prob = 0.2), c(0L, 64L))
-  expect_identical(ran_beta_binom(1, c(10, 100), theta = 1, prob = 0.2), 4L)
+  withr::with_seed(101, {
+    expect_identical(ran_beta_binom(), 0L)
+    expect_identical(ran_beta_binom(2), c(0L, 1L))
+    expect_identical(ran_beta_binom(2, 10), c(6L, 4L))
+    expect_identical(ran_beta_binom(2, c(5, 10)), c(2L, 5L))
+    expect_identical(ran_beta_binom(1, c(5, 10)), 2L)
+  })
+  withr::with_seed(101, {
+    expect_identical(ran_beta_binom(prob = 0.2), 0L)
+    expect_identical(ran_beta_binom(2, prob = 0.2), c(0L, 0L))
+    expect_identical(ran_beta_binom(2, 10, prob = 0.2), c(2L, 1L))
+    expect_identical(ran_beta_binom(2, c(5, 10), prob = 0.2), c(0L, 2L))
+    expect_identical(ran_beta_binom(1, c(5, 10), prob = 0.2), 1L)
+    expect_identical(ran_beta_binom(1, 0, prob = 0.2), 0L)
+    expect_identical(ran_beta_binom(1, 0, prob = 0.9), 0L)
+  })
+  withr::with_seed(101, {
+    expect_identical(ran_beta_binom(theta = 10), 1L)
+    expect_identical(ran_beta_binom(2, theta = 10), c(0L, 1L))
+    expect_identical(ran_beta_binom(2, 10, theta = 10), c(0L, 10L))
+    expect_identical(ran_beta_binom(2, 10, theta = 10), c(0L, 0L))
+    expect_identical(ran_beta_binom(2, c(10, 100), theta = 1), c(2L, 70L))
+    expect_identical(ran_beta_binom(2, c(10, 100), theta = 1), c(10L, 54L))
+    expect_identical(ran_beta_binom(1, c(10, 100), theta = 1), 6L)
+  })
+  withr::with_seed(101, {
+    expect_identical(ran_beta_binom(theta = 0.5, prob = 0.2), 1L)
+    expect_identical(ran_beta_binom(2, theta = 0.5, prob = 0.2), c(0L, 1L))
+    expect_identical(ran_beta_binom(2, 10, theta = 0.5, prob = 0.2), c(4L, 1L))
+    expect_identical(ran_beta_binom(2, 10, theta = 0.5, prob = 0.2), c(0L, 5L))
+    expect_identical(
+      ran_beta_binom(2, c(10, 100), theta = 1, prob = 0.2),
+      c(0L, 0L)
+    )
+    expect_identical(
+      ran_beta_binom(2, c(10, 100), theta = 1, prob = 0.2),
+      c(0L, 64L)
+    )
+    expect_identical(ran_beta_binom(1, c(10, 100), theta = 1, prob = 0.2), 4L)
+  })
 })
 
 test_that("ran_skewnorm", {
@@ -248,34 +355,77 @@ test_that("ran_skewnorm", {
   expect_error(ran_skewnorm(integer(0)))
   expect_error(ran_skewnorm(1, 0, sd = -1))
   expect_identical(ran_skewnorm(0L), numeric(0))
-  set.seed(101)
-  expect_equal(ran_skewnorm(), 0.552461855419139)
-  expect_equal(ran_skewnorm(2), c(0.214359459043425, 1.1739662875627))
-  expect_equal(ran_skewnorm(2, 10), c(9.88726568524578, 9.77674063537274))
-  expect_equal(ran_skewnorm(2, c(5, 10)), c(4.20515556458494, 8.53318030583653))
-  expect_equal(ran_skewnorm(1, c(5, 10)), c(4.8066620350025))
-  set.seed(101)
-  expect_equal(ran_skewnorm(sd = 1), 0.552461855419139)
-  expect_equal(ran_skewnorm(2, sd = 2), c(0.428718918086851, 2.3479325751254))
-  expect_equal(ran_skewnorm(2, 10, sd = 3), c(9.66179705573736, 9.33022190611821))
-  expect_equal(ran_skewnorm(2, c(5, 10), sd = 2), c(3.41031112916989, 7.06636061167307))
-  expect_equal(ran_skewnorm(1, c(5, 10), sd = 1), c(4.8066620350025))
-  expect_equal(ran_skewnorm(1, 0, sd = 3), 0.175396493548505)
-  expect_equal(ran_skewnorm(1, 0, sd = 4), -8.20123126255853)
-  set.seed(101)
-  expect_equal(ran_skewnorm(shape = 10), 0.379390442659801)
-  expect_equal(ran_skewnorm(2, shape = 10), c(0.692923789421489, 0.426040940417248))
-  expect_equal(ran_skewnorm(2, 10, shape = 10), c(10.6045014356932, 10.8902621154531))
-  expect_equal(ran_skewnorm(2, 10, shape = 10), c(10.4447454597277, 11.2747158507856))
-  expect_equal(ran_skewnorm(2, c(10, 100), shape = -1), c(9.69592899188521, 99.4404740107593))
-  expect_equal(ran_skewnorm(2, c(10, 100), shape = -1), c(7.97203318662633, 100.385208042625))
-  expect_equal(ran_skewnorm(1, c(10, 100), shape = -1), c(8.77536013503756))
-  set.seed(101)
-  expect_equal(ran_skewnorm(sd = 1, shape = 5), 0.428051766065545)
-  expect_equal(ran_skewnorm(2, sd = 1, shape = 5), c(0.703876239197544, 0.534968020196629))
-  expect_equal(ran_skewnorm(2, 10, sd = 3, shape = 5), c(11.7539930699001, 12.5663063681019))
-  expect_equal(ran_skewnorm(2, 10, sd = 2, shape = -2), c(8.3473305357842, 6.13398981871521))
-  expect_equal(ran_skewnorm(2, c(10, 100), sd = 5, shape = -2), c(8.50920292023333, 96.3305141003515))
-  expect_equal(ran_skewnorm(2, c(10, 100), sd = 0, shape = -1), c(10, 100))
-  expect_equal(ran_skewnorm(1, c(10, 100), sd = 10, shape = -1), c(-2.24639864962439))
+  withr::with_seed(101, {
+    expect_equal(ran_skewnorm(), 0.552461855419139)
+    expect_equal(ran_skewnorm(2), c(0.214359459043425, 1.1739662875627))
+    expect_equal(ran_skewnorm(2, 10), c(9.88726568524578, 9.77674063537274))
+    expect_equal(
+      ran_skewnorm(2, c(5, 10)),
+      c(4.20515556458494, 8.53318030583653)
+    )
+    expect_equal(ran_skewnorm(1, c(5, 10)), c(4.8066620350025))
+  })
+  withr::with_seed(101, {
+    expect_equal(ran_skewnorm(sd = 1), 0.552461855419139)
+    expect_equal(ran_skewnorm(2, sd = 2), c(0.428718918086851, 2.3479325751254))
+    expect_equal(
+      ran_skewnorm(2, 10, sd = 3),
+      c(9.66179705573736, 9.33022190611821)
+    )
+    expect_equal(
+      ran_skewnorm(2, c(5, 10), sd = 2),
+      c(3.41031112916989, 7.06636061167307)
+    )
+    expect_equal(ran_skewnorm(1, c(5, 10), sd = 1), c(4.8066620350025))
+    expect_equal(ran_skewnorm(1, 0, sd = 3), 0.175396493548505)
+    expect_equal(ran_skewnorm(1, 0, sd = 4), -8.20123126255853)
+  })
+  withr::with_seed(101, {
+    expect_equal(ran_skewnorm(shape = 10), 0.379390442659801)
+    expect_equal(
+      ran_skewnorm(2, shape = 10),
+      c(0.692923789421489, 0.426040940417248)
+    )
+    expect_equal(
+      ran_skewnorm(2, 10, shape = 10),
+      c(10.6045014356932, 10.8902621154531)
+    )
+    expect_equal(
+      ran_skewnorm(2, 10, shape = 10),
+      c(10.4447454597277, 11.2747158507856)
+    )
+    expect_equal(
+      ran_skewnorm(2, c(10, 100), shape = -1),
+      c(9.69592899188521, 99.4404740107593)
+    )
+    expect_equal(
+      ran_skewnorm(2, c(10, 100), shape = -1),
+      c(7.97203318662633, 100.385208042625)
+    )
+    expect_equal(ran_skewnorm(1, c(10, 100), shape = -1), c(8.77536013503756))
+  })
+  withr::with_seed(101, {
+    expect_equal(ran_skewnorm(sd = 1, shape = 5), 0.428051766065545)
+    expect_equal(
+      ran_skewnorm(2, sd = 1, shape = 5),
+      c(0.703876239197544, 0.534968020196629)
+    )
+    expect_equal(
+      ran_skewnorm(2, 10, sd = 3, shape = 5),
+      c(11.7539930699001, 12.5663063681019)
+    )
+    expect_equal(
+      ran_skewnorm(2, 10, sd = 2, shape = -2),
+      c(8.3473305357842, 6.13398981871521)
+    )
+    expect_equal(
+      ran_skewnorm(2, c(10, 100), sd = 5, shape = -2),
+      c(8.50920292023333, 96.3305141003515)
+    )
+    expect_equal(ran_skewnorm(2, c(10, 100), sd = 0, shape = -1), c(10, 100))
+    expect_equal(
+      ran_skewnorm(1, c(10, 100), sd = 10, shape = -1),
+      c(-2.24639864962439)
+    )
+  })
 })

--- a/tests/testthat/test-res.R
+++ b/tests/testthat/test-res.R
@@ -11,30 +11,47 @@ test_that("res_pois", {
     res_pois(c(1, 3.5, 4), 3, type = "raw"),
     c(-2, 0.5, 1)
   )
-  set.seed(101)
-  expect_equal(res_pois(1:2, 2, simulate = TRUE, type = "raw"), c(-1L, -2L))
-  expect_equal(res_pois(1:2, 2, simulate = TRUE), c(0.657868260861539, 0))
-  set.seed(101)
-  expect_equal(res_pois(1:2, 2, simulate = TRUE, type = "raw"), c(-1L, -2L))
-  expect_equal(res_pois(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_pois(1:2, 2, simulate = TRUE, type = "data"), c(1L, 0L))
-  set.seed(101)
-  expect_equal(
-    res_pois(1:2, 2, simulate = TRUE, type = "standardized"),
-    c(-0.707106781186547, -1.4142135623731)
-  )
+  withr::with_seed(101, {
+    expect_equal(res_pois(1:2, 2, simulate = TRUE, type = "raw"), c(-1L, -2L))
+    expect_equal(
+      res_pois(1:2, 2, simulate = TRUE),
+      c(0.657868260861539, 0)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(res_pois(1:2, 2, simulate = TRUE, type = "raw"), c(-1L, -2L))
+    expect_equal(res_pois(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_pois(1:2, 2, simulate = TRUE, type = "data"),
+      c(1L, 0L)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_pois(1:2, 2, simulate = TRUE, type = "standardized"),
+      c(-0.707106781186547, -1.4142135623731)
+    )
+  })
 })
 
 test_that("res_pois simulate", {
-  set.seed(101)
-  res <- res_pois(rep(2, 10000), lambda = 10, simulate = TRUE, type = "dev")
-  expect_equal(mean(res), -0.0747938731623342)
-  expect_equal(sd(res), 1.00265783064155)
-  set.seed(101)
-  res <- res_pois(rep(2, 10000), lambda = 10, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), -0.0207445414507045)
-  expect_equal(sd(res), 0.991366705510403)
+  withr::with_seed(101, {
+    res <- res_pois(
+      rep(2, 10000), lambda = 10, simulate = TRUE, type = "dev"
+    )
+    expect_equal(mean(res), -0.0747938731623342)
+    expect_equal(sd(res), 1.00265783064155)
+  })
+  withr::with_seed(101, {
+    res <- res_pois(
+      rep(2, 10000), lambda = 10,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), -0.0207445414507045)
+    expect_equal(sd(res), 0.991366705510403)
+  })
 })
 
 test_that("res_pois_zi", {
@@ -55,43 +72,73 @@ test_that("res_pois_zi", {
     res_pois_zi(c(1, 3.5, 4), 3, type = "raw"),
     c(-2, 0.5, 1)
   )
-  set.seed(101)
-  expect_equal(res_pois_zi(1:2, 2, simulate = TRUE, type = "raw"), c(-1L, -2L))
-  expect_equal(res_pois_zi(1:2, 2, simulate = TRUE), c(0.657868260861539, 0))
-  set.seed(101)
-  expect_equal(res_pois_zi(1:2, 2, simulate = TRUE, type = "raw"), c(-1L, -2L))
-  expect_equal(res_pois_zi(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_pois_zi(1:2, 2, simulate = TRUE, type = "data"), c(1L, 0L))
-  set.seed(101)
-  expect_equal(
-    res_pois_zi(1:10, 10, 0.5, simulate = TRUE, type = "data"),
-    c(0L, 11L, 7L, 8L, 0L, 0L, 0L, 10L, 0L, 0L)
-  )
-  set.seed(101)
-  expect_equal(
-    res_pois_zi(1:10, 10, 0.5, simulate = TRUE, type = "standardized"),
-    c(
-      -0.912870929175277, 1.09544511501033, 0.365148371670111, 0.547722557505166,
-      -0.912870929175277, -0.912870929175277, -0.912870929175277, 0.912870929175277,
-      -0.912870929175277, -0.912870929175277
+  withr::with_seed(101, {
+    expect_equal(
+      res_pois_zi(1:2, 2, simulate = TRUE, type = "raw"),
+      c(-1L, -2L)
     )
-  )
+    expect_equal(
+      res_pois_zi(1:2, 2, simulate = TRUE),
+      c(0.657868260861539, 0)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_pois_zi(1:2, 2, simulate = TRUE, type = "raw"),
+      c(-1L, -2L)
+    )
+    expect_equal(res_pois_zi(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_pois_zi(1:2, 2, simulate = TRUE, type = "data"),
+      c(1L, 0L)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_pois_zi(1:10, 10, 0.5, simulate = TRUE, type = "data"),
+      c(0L, 11L, 7L, 8L, 0L, 0L, 0L, 10L, 0L, 0L)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_pois_zi(1:10, 10, 0.5, simulate = TRUE, type = "standardized"),
+      c(
+        -0.912870929175277, 1.09544511501033,
+        0.365148371670111, 0.547722557505166,
+        -0.912870929175277, -0.912870929175277,
+        -0.912870929175277, 0.912870929175277,
+        -0.912870929175277, -0.912870929175277
+      )
+    )
+  })
 })
 
 test_that("res_pois_zi simulate", {
-  set.seed(101)
-  res <- res_pois_zi(rep(2, 10000), lambda = 100, prob = 0.01, simulate = TRUE, type = "dev")
-  expect_equal(mean(res), -0.0391353490642631)
-  expect_equal(sd(res), 1.04793224317444)
-  set.seed(101)
-  res <- res_pois_zi(rep(2, 10000), lambda = 100, prob = 0.01, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), 0.00328329103187647)
-  expect_equal(sd(res), 0.971476934943575)
+  withr::with_seed(101, {
+    res <- res_pois_zi(
+      rep(2, 10000), lambda = 100, prob = 0.01,
+      simulate = TRUE, type = "dev"
+    )
+    expect_equal(mean(res), -0.0391353490642631)
+    expect_equal(sd(res), 1.04793224317444)
+  })
+  withr::with_seed(101, {
+    res <- res_pois_zi(
+      rep(2, 10000), lambda = 100, prob = 0.01,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), 0.00328329103187647)
+    expect_equal(sd(res), 0.971476934943575)
+  })
 })
 
 test_that("res_norm", {
-  expect_identical(res_norm(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_norm(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_norm(0), 0)
   expect_identical(res_norm(NA, 1, 1), NA_real_)
   expect_identical(res_norm(1, NA, 1), NA_real_)
@@ -102,32 +149,58 @@ test_that("res_norm", {
   expect_equal(res_norm(-2:2, type = "raw"), -2:2)
   expect_equal(res_norm(-2:2, mean = 2, type = "raw"), -4:0)
   expect_equal(res_norm(-2:2, mean = -2:2, type = "raw"), rep(0, 5))
-  set.seed(101)
-  expect_equal(res_norm(1:2, 2, simulate = TRUE, type = "raw"), c(-0.326036490515386, 0.552461855419138))
-  expect_equal(res_norm(1:2, 2, simulate = TRUE), c(-0.67494384395583, 0.214359459043425))
-  set.seed(101)
-  expect_equal(res_norm(1:2, 2, simulate = TRUE, type = "raw"), c(-0.326036490515386, 0.552461855419138))
-  expect_equal(res_norm(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_norm(1:2, 2, simulate = TRUE, type = "data"), c(1.67396350948461, 2.55246185541914))
-  set.seed(101)
-  expect_equal(res_norm(1:2, 2, simulate = TRUE, type = "standardized"), c(-0.326036490515386, 0.552461855419138))
+  withr::with_seed(101, {
+    expect_equal(
+      res_norm(1:2, 2, simulate = TRUE, type = "raw"),
+      c(-0.326036490515386, 0.552461855419138)
+    )
+    expect_equal(
+      res_norm(1:2, 2, simulate = TRUE),
+      c(-0.67494384395583, 0.214359459043425)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_norm(1:2, 2, simulate = TRUE, type = "raw"),
+      c(-0.326036490515386, 0.552461855419138)
+    )
+    expect_equal(res_norm(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_norm(1:2, 2, simulate = TRUE, type = "data"),
+      c(1.67396350948461, 2.55246185541914)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_norm(1:2, 2, simulate = TRUE, type = "standardized"),
+      c(-0.326036490515386, 0.552461855419138)
+    )
+  })
   expect_error(res_norm(10, type = "unknown"))
 })
 
 test_that("res_norm simulate", {
-  set.seed(101)
-  res <- res_norm(rep(2, 10000), simulate = TRUE, type = "dev")
-  expect_equal(mean(res), 0.00527789283092907)
-  expect_equal(sd(res), 0.993174129657874)
-  set.seed(101)
-  res <- res_norm(rep(2, 10000), simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), 0.0052778928309291)
-  expect_equal(sd(res), 0.993174129657875)
+  withr::with_seed(101, {
+    res <- res_norm(rep(2, 10000), simulate = TRUE, type = "dev")
+    expect_equal(mean(res), 0.00527789283092907)
+    expect_equal(sd(res), 0.993174129657874)
+  })
+  withr::with_seed(101, {
+    res <- res_norm(
+      rep(2, 10000), simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), 0.0052778928309291)
+    expect_equal(sd(res), 0.993174129657875)
+  })
 })
 
 test_that("res_lnorm", {
-  expect_identical(res_lnorm(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_lnorm(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_lnorm(exp(0)), 0)
   expect_identical(res_lnorm(1), 0)
   expect_identical(res_lnorm(0), -Inf)
@@ -142,25 +215,48 @@ test_that("res_lnorm", {
   )
   expect_equal(res_lnorm(1, type = "raw"), 0)
   expect_equal(res_lnorm(exp(1), type = "raw"), 1.71828182845905)
-  set.seed(101)
-  expect_equal(res_lnorm(1:2, 2, simulate = TRUE, type = "raw"), c(-2.05579169361621, 5.44961576366372))
-  expect_equal(res_lnorm(1:2, 2, simulate = TRUE), c(-0.67494384395583, 0.214359459043425))
-  set.seed(101)
-  expect_equal(res_lnorm(1:2, 2, simulate = TRUE, type = "raw"), c(-2.05579169361621, 5.44961576366372))
-  expect_equal(res_lnorm(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_lnorm(1:2, 2, simulate = TRUE, type = "data"), c(5.33326440531444, 12.8386718625944))
-  set.seed(101)
-  expect_equal(res_lnorm(1:2, 2, simulate = TRUE, type = "standardized"), c(-0.428902244197459, 0.0410901945157245))
-  set.seed(101)
-  res <- res_lnorm(rep(2, 10000), simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), -0.000972725402704599)
-  expect_equal(sd(res), 0.96810060574941)
+  withr::with_seed(101, {
+    expect_equal(
+      res_lnorm(1:2, 2, simulate = TRUE, type = "raw"),
+      c(-2.05579169361621, 5.44961576366372)
+    )
+    expect_equal(
+      res_lnorm(1:2, 2, simulate = TRUE),
+      c(-0.67494384395583, 0.214359459043425)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_lnorm(1:2, 2, simulate = TRUE, type = "raw"),
+      c(-2.05579169361621, 5.44961576366372)
+    )
+    expect_equal(res_lnorm(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_lnorm(1:2, 2, simulate = TRUE, type = "data"),
+      c(5.33326440531444, 12.8386718625944)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_lnorm(1:2, 2, simulate = TRUE, type = "standardized"),
+      c(-0.428902244197459, 0.0410901945157245)
+    )
+  })
+  withr::with_seed(101, {
+    res <- res_lnorm(rep(2, 10000), simulate = TRUE, type = "standardized")
+    expect_equal(mean(res), -0.000972725402704599)
+    expect_equal(sd(res), 0.96810060574941)
+  })
   expect_error(res_lnorm(10, type = "unknown"))
 })
 
 test_that("res_binom", {
-  expect_identical(res_binom(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_binom(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_binom(NA, 1, 1), NA_real_)
   expect_identical(res_binom(1, NA, 1), NA_real_)
   expect_identical(res_binom(1, 1, NA), NA_real_)
@@ -175,33 +271,58 @@ test_that("res_binom", {
   expect_equal(
     res_binom(1:9, 10, 0.5),
     c(
-      -2.71316865369073, -1.96338868806845, -1.28283185573988, -0.634594572159089,
-      0, 0.634594572159089, 1.28283185573988, 1.96338868806845, 2.71316865369073
+      -2.71316865369073, -1.96338868806845,
+      -1.28283185573988, -0.634594572159089,
+      0, 0.634594572159089, 1.28283185573988,
+      1.96338868806845, 2.71316865369073
     )
   )
   expect_equal(res_binom(0, 2, 0.5, type = "raw"), -1)
-  set.seed(101)
-  expect_equal(res_binom(1:2, simulate = TRUE, type = "raw"), c(-0.5, -0.5))
-  expect_equal(res_binom(1:2, 2, simulate = TRUE), c(0, 0))
-  set.seed(101)
-  expect_equal(res_binom(1:2, simulate = TRUE, type = "raw"), c(-0.5, -0.5))
-  expect_equal(res_binom(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_binom(1:2, 2, simulate = TRUE, type = "data"), 1:0)
-  set.seed(101)
-  expect_equal(res_binom(1:2, 2, simulate = TRUE, type = "standardized"), c(0, -1.4142135623731))
+  withr::with_seed(101, {
+    expect_equal(
+      res_binom(1:2, simulate = TRUE, type = "raw"),
+      c(-0.5, -0.5)
+    )
+    expect_equal(res_binom(1:2, 2, simulate = TRUE), c(0, 0))
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_binom(1:2, simulate = TRUE, type = "raw"),
+      c(-0.5, -0.5)
+    )
+    expect_equal(res_binom(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_binom(1:2, 2, simulate = TRUE, type = "data"),
+      1:0
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_binom(1:2, 2, simulate = TRUE, type = "standardized"),
+      c(0, -1.4142135623731)
+    )
+  })
   expect_error(res_binom(10, type = "unknown"))
 })
 
 test_that("res_binom simulate", {
-  set.seed(101)
-  res <- res_binom(rep(2, 10000), size = 10, simulate = TRUE, type = "dev")
-  expect_equal(mean(res), 0.00262573802624805)
-  expect_equal(sd(res), 1.02781369459726)
-  set.seed(101)
-  res <- res_binom(rep(2, 10000), 10, 0.5, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), 0.00252982212813479)
-  expect_equal(sd(res), 0.998525565686988)
+  withr::with_seed(101, {
+    res <- res_binom(
+      rep(2, 10000), size = 10, simulate = TRUE, type = "dev"
+    )
+    expect_equal(mean(res), 0.00262573802624805)
+    expect_equal(sd(res), 1.02781369459726)
+  })
+  withr::with_seed(101, {
+    res <- res_binom(
+      rep(2, 10000), 10, 0.5,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), 0.00252982212813479)
+    expect_equal(sd(res), 0.998525565686988)
+  })
 })
 
 test_that("res_bern", {
@@ -231,32 +352,58 @@ test_that("res_bern", {
     c(0.844600430900592, -1.17741002251547)
   )
   expect_equal(res_bern(c(0, 1), c(1, 0), type = "raw"), c(-1, 1))
-  set.seed(101)
-  expect_equal(res_bern(1:2, simulate = TRUE, type = "raw"), c(-0.5, -0.5))
-  expect_equal(res_bern(1:2, simulate = TRUE), c(1.17741002251547, 1.17741002251547))
-  set.seed(101)
-  expect_equal(res_bern(1:2, simulate = TRUE, type = "raw"), c(-0.5, -0.5))
-  expect_equal(res_bern(1:2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_bern(0:1, simulate = TRUE, type = "data"), c(0L, 0L))
-  set.seed(101)
-  expect_equal(res_bern(0:1, simulate = TRUE, type = "standardized"), c(-1L, -1L))
+  withr::with_seed(101, {
+    expect_equal(
+      res_bern(1:2, simulate = TRUE, type = "raw"),
+      c(-0.5, -0.5)
+    )
+    expect_equal(
+      res_bern(1:2, simulate = TRUE),
+      c(1.17741002251547, 1.17741002251547)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_bern(1:2, simulate = TRUE, type = "raw"),
+      c(-0.5, -0.5)
+    )
+    expect_equal(res_bern(1:2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_bern(0:1, simulate = TRUE, type = "data"),
+      c(0L, 0L)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_bern(0:1, simulate = TRUE, type = "standardized"),
+      c(-1L, -1L)
+    )
+  })
   expect_error(res_bern(0, type = "unknown"))
 })
 
 test_that("res_bern simulate", {
-  set.seed(101)
-  res <- res_bern(rep(2, 10000), simulate = TRUE, type = "dev")
-  expect_equal(mean(res), -0.00659349612608666)
-  expect_equal(sd(res), 1.17745043457519)
-  set.seed(101)
-  res <- res_bern(rep(2, 10000), simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), -0.00559999999999963)
-  expect_equal(sd(res), 1.00003432284339)
+  withr::with_seed(101, {
+    res <- res_bern(rep(2, 10000), simulate = TRUE, type = "dev")
+    expect_equal(mean(res), -0.00659349612608666)
+    expect_equal(sd(res), 1.17745043457519)
+  })
+  withr::with_seed(101, {
+    res <- res_bern(
+      rep(2, 10000), simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), -0.00559999999999963)
+    expect_equal(sd(res), 1.00003432284339)
+  })
 })
 
 test_that("res_gamma_pois", {
-  expect_identical(res_gamma_pois(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_gamma_pois(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_gamma_pois(1, 1, 0), 0)
   expect_equal(res_gamma_pois(0, 1, 0), -1.4142135623731)
   expect_identical(res_gamma_pois(1, 1, 1), 0)
@@ -265,36 +412,69 @@ test_that("res_gamma_pois", {
   expect_identical(res_gamma_pois(1, 1, NA), NA_real_)
   expect_error(res_gamma_pois(1, 3, 1, type = "unknown"))
   expect_equal(res_gamma_pois(1, 3, 1, type = "raw"), -2)
-  expect_equal(res_gamma_pois(1, 3, 2), dev_gamma_pois(1, 3, 2, res = TRUE))
+  expect_equal(
+    res_gamma_pois(1, 3, 2),
+    dev_gamma_pois(1, 3, 2, res = TRUE)
+  )
   expect_equal(
     res_gamma_pois(c(1, 3.5, 4), 3, 10, type = "raw"),
     c(-2, 0.5, 1)
   )
-  set.seed(101)
-  expect_identical(res_gamma_pois(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-1, 2))
-  expect_equal(res_gamma_pois(1:2, 2, 2, simulate = TRUE), c(0.699911676381084, -0.382338214383655))
-  set.seed(101)
-  expect_identical(res_gamma_pois(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-1, 2))
-  expect_equal(res_gamma_pois(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_gamma_pois(1:2, 2, simulate = TRUE, type = "data"), 2:1)
-  set.seed(101)
-  expect_equal(res_gamma_pois(1:2, 2, simulate = TRUE, type = "standardized"), c(0, -0.707106781186547))
+  withr::with_seed(101, {
+    expect_identical(
+      res_gamma_pois(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-1, 2)
+    )
+    expect_equal(
+      res_gamma_pois(1:2, 2, 2, simulate = TRUE),
+      c(0.699911676381084, -0.382338214383655)
+    )
+  })
+  withr::with_seed(101, {
+    expect_identical(
+      res_gamma_pois(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-1, 2)
+    )
+    expect_equal(res_gamma_pois(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma_pois(1:2, 2, simulate = TRUE, type = "data"),
+      2:1
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma_pois(1:2, 2, simulate = TRUE, type = "standardized"),
+      c(0, -0.707106781186547)
+    )
+  })
 })
 
 test_that("res_gamma_pois simulate", {
-  set.seed(101)
-  res <- res_gamma_pois(rep(2, 10000), lambda = 100, theta = 0.5, simulate = TRUE, type = "dev")
-  expect_equal(mean(res), -0.250801462240149)
-  expect_equal(sd(res), 1.01494516351537)
-  set.seed(101)
-  res <- res_gamma_pois(rep(2, 10000), lambda = 100, theta = 0.5, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), -0.00860612139643616)
-  expect_equal(sd(res), 0.999023530246265)
+  withr::with_seed(101, {
+    res <- res_gamma_pois(
+      rep(2, 10000), lambda = 100, theta = 0.5,
+      simulate = TRUE, type = "dev"
+    )
+    expect_equal(mean(res), -0.250801462240149)
+    expect_equal(sd(res), 1.01494516351537)
+  })
+  withr::with_seed(101, {
+    res <- res_gamma_pois(
+      rep(2, 10000), lambda = 100, theta = 0.5,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), -0.00860612139643616)
+    expect_equal(sd(res), 0.999023530246265)
+  })
 })
 
 test_that("res_neg_binom", {
-  expect_identical(res_neg_binom(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_neg_binom(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_neg_binom(1, 1, 0), 0)
   expect_equal(res_neg_binom(0, 1, 0), -1.4142135623731)
   expect_identical(res_neg_binom(1, 1, 1), 0)
@@ -303,29 +483,58 @@ test_that("res_neg_binom", {
   expect_identical(res_neg_binom(1, 1, NA), NA_real_)
   expect_error(res_neg_binom(1, 3, 1, type = "unknown"))
   expect_equal(res_neg_binom(1, 3, 1, type = "raw"), -2)
-  expect_equal(res_neg_binom(1, 3, 2), dev_gamma_pois(1, 3, 2, res = TRUE))
+  expect_equal(
+    res_neg_binom(1, 3, 2),
+    dev_gamma_pois(1, 3, 2, res = TRUE)
+  )
   expect_equal(
     res_neg_binom(c(1, 3.5, 4), 3, 10, type = "raw"),
     c(-2, 0.5, 1)
   )
-  set.seed(101)
-  expect_identical(res_neg_binom(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-1, 2))
-  expect_equal(res_neg_binom(1:2, 2, 2, simulate = TRUE), c(0.699911676381084, -0.382338214383655))
-  set.seed(101)
-  expect_identical(res_neg_binom(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-1, 2))
-  expect_equal(res_neg_binom(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_neg_binom(1:2, 2, simulate = TRUE, type = "data"), 2:1)
-  set.seed(101)
-  expect_equal(res_neg_binom(1:2, 2, simulate = TRUE, type = "standardized"), c(0, -0.707106781186547))
-  set.seed(101)
-  res <- res_neg_binom(rep(2, 10000), 2, 2, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), -0.0100560429593354)
-  expect_equal(sd(res), 0.973207885992976)
+  withr::with_seed(101, {
+    expect_identical(
+      res_neg_binom(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-1, 2)
+    )
+    expect_equal(
+      res_neg_binom(1:2, 2, 2, simulate = TRUE),
+      c(0.699911676381084, -0.382338214383655)
+    )
+  })
+  withr::with_seed(101, {
+    expect_identical(
+      res_neg_binom(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-1, 2)
+    )
+    expect_equal(res_neg_binom(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_neg_binom(1:2, 2, simulate = TRUE, type = "data"),
+      2:1
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_neg_binom(1:2, 2, simulate = TRUE, type = "standardized"),
+      c(0, -0.707106781186547)
+    )
+  })
+  withr::with_seed(101, {
+    res <- res_neg_binom(
+      rep(2, 10000), 2, 2,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), -0.0100560429593354)
+    expect_equal(sd(res), 0.973207885992976)
+  })
 })
 
 test_that("res_gamma_pois_zi", {
-  expect_identical(res_gamma_pois_zi(integer(0), integer(0), integer(0)), numeric(0), numeric(0))
+  expect_identical(
+    res_gamma_pois_zi(integer(0), integer(0), integer(0)),
+    numeric(0), numeric(0)
+  )
   expect_identical(res_gamma_pois_zi(1, 1, 0, 0), 0)
   expect_identical(res_gamma_pois_zi(1, 1, 0, 0, type = "raw"), 0)
   expect_equal(res_gamma_pois_zi(1, 1, 0, 0.5), 1.17741002251547)
@@ -343,8 +552,12 @@ test_that("res_gamma_pois_zi", {
   expect_error(res_gamma_pois_zi(1, 3, 1, type = "unknown"))
   expect_equal(res_gamma_pois_zi(1, 3, 1, type = "raw"), -2)
   expect_equal(res_gamma_pois_zi(1, 3), dev_pois(1, 3, res = TRUE))
-  expect_equal(res_gamma_pois_zi(1, 3, 2), dev_gamma_pois(1, 3, 2, res = TRUE))
-  #  expect_equal(res_gamma_pois_zi(1, 3, prob = 0.5), dev_pois_zi(1, 3, prob = 0.5, res = TRUE))
+  expect_equal(
+    res_gamma_pois_zi(1, 3, 2),
+    dev_gamma_pois(1, 3, 2, res = TRUE)
+  )
+  #  expect_equal(res_gamma_pois_zi(1, 3, prob = 0.5),
+  # dev_pois_zi(1, 3, prob = 0.5, res = TRUE))
   expect_equal(
     res_gamma_pois_zi(c(1, 3.5, 4), 3, 10, type = "raw"),
     c(-2, 0.5, 1)
@@ -353,35 +566,80 @@ test_that("res_gamma_pois_zi", {
     res_gamma_pois_zi(c(1, 3.5, 4), 3, 10, 0.5, type = "raw"),
     c(-0.5, 2, 2.5)
   )
-  set.seed(101)
-  expect_identical(res_gamma_pois_zi(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-1, 2))
-  expect_equal(res_gamma_pois_zi(1:2, 2, 2, simulate = TRUE), c(0.699911676381084, -0.382338214383655))
-  set.seed(101)
-  expect_identical(res_gamma_pois_zi(1:2, 2, 2, 0.5, simulate = TRUE, type = "raw"), c(0, 3))
-  expect_equal(res_gamma_pois_zi(1:2, 2, 2, 0.5, simulate = TRUE), c(1.36973381204323, -0.80437196763369))
-  set.seed(101)
-  expect_identical(res_gamma_pois_zi(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-1, 2))
-  expect_equal(res_gamma_pois_zi(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_identical(res_gamma_pois_zi(1:2, 2, 2, 0.5, simulate = TRUE, type = "raw"), c(0, 3))
-  expect_equal(res_gamma_pois_zi(1:2, 2, prob = 0.5, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_gamma_pois_zi(1:2, 2, simulate = TRUE, type = "data"), 2:1)
-  set.seed(101)
-  expect_equal(res_gamma_pois_zi(1:2, 2, prob = 0.7, simulate = TRUE, type = "data"), c(0L, 0L))
-  set.seed(101)
-  expect_equal(
-    res_gamma_pois_zi(1:2, 2, prob = 0.7, simulate = TRUE, type = "standardized"),
-    c(-0.424264068711929, -0.424264068711929)
-  )
-  set.seed(101)
-  res <- res_gamma_pois_zi(rep(2, 10000), 2, prob = 0.7, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), 0.00593969696196716)
-  expect_equal(sd(res), 0.860406154019735)
+  withr::with_seed(101, {
+    expect_identical(
+      res_gamma_pois_zi(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-1, 2)
+    )
+    expect_equal(
+      res_gamma_pois_zi(1:2, 2, 2, simulate = TRUE),
+      c(0.699911676381084, -0.382338214383655)
+    )
+  })
+  withr::with_seed(101, {
+    expect_identical(
+      res_gamma_pois_zi(1:2, 2, 2, 0.5, simulate = TRUE, type = "raw"),
+      c(0, 3)
+    )
+    expect_equal(
+      res_gamma_pois_zi(1:2, 2, 2, 0.5, simulate = TRUE),
+      c(1.36973381204323, -0.80437196763369)
+    )
+  })
+  withr::with_seed(101, {
+    expect_identical(
+      res_gamma_pois_zi(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-1, 2)
+    )
+    expect_equal(res_gamma_pois_zi(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_identical(
+      res_gamma_pois_zi(1:2, 2, 2, 0.5, simulate = TRUE, type = "raw"),
+      c(0, 3)
+    )
+    expect_equal(
+      res_gamma_pois_zi(1:2, 2, prob = 0.5, type = "data"),
+      1:2
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma_pois_zi(1:2, 2, simulate = TRUE, type = "data"),
+      2:1
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma_pois_zi(
+        1:2, 2, prob = 0.7, simulate = TRUE, type = "data"
+      ),
+      c(0L, 0L)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma_pois_zi(
+        1:2, 2, prob = 0.7, simulate = TRUE, type = "standardized"
+      ),
+      c(-0.424264068711929, -0.424264068711929)
+    )
+  })
+  withr::with_seed(101, {
+    res <- res_gamma_pois_zi(
+      rep(2, 10000), 2, prob = 0.7,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), 0.00593969696196716)
+    expect_equal(sd(res), 0.860406154019735)
+  })
 })
 
 test_that("res_gamma", {
-  expect_identical(res_gamma(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_gamma(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_gamma(1, 1, 1), 0)
   expect_identical(res_gamma(1, 1, 1, type = "raw"), 0)
   expect_equal(res_gamma(1, 1, 0.5, type = "raw"), -1)
@@ -402,24 +660,52 @@ test_that("res_gamma", {
     res_gamma(c(1, 3.5, 4), 3, 5, type = "raw"),
     c(0.4, 2.9, 3.4)
   )
-  set.seed(101)
-  expect_equal(res_gamma(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-0.436368285679167, 0.0193475947038637))
-  expect_equal(res_gamma(1:2, 2, 2, simulate = TRUE), c(-0.682136415630992, -0.0483989592818978))
-  set.seed(101)
-  expect_equal(res_gamma(1:2, 2, 0.5, simulate = TRUE, type = "raw"), c(-1.74547314271667, 0.0773903788154549))
-  expect_equal(res_gamma(1:2, 2, 0.5, simulate = TRUE), c(-0.682136415630992, -0.0483989592818978))
-  set.seed(101)
-  expect_equal(res_gamma(1:2, 2, 1, simulate = TRUE, type = "data"), c(1.12726342864167, 2.03869518940773))
-  set.seed(101)
-  expect_equal(res_gamma(1:2, 2, 1, simulate = TRUE, type = "standardized"), c(-0.617117947796975, 0.0273616308295019))
-  set.seed(101)
-  res <- res_gamma(rep(2, 10000), 2, 1, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), 0.00754439840612374)
-  expect_equal(sd(res), 1.00440120529188)
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-0.436368285679167, 0.0193475947038637)
+    )
+    expect_equal(
+      res_gamma(1:2, 2, 2, simulate = TRUE),
+      c(-0.682136415630992, -0.0483989592818978)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma(1:2, 2, 0.5, simulate = TRUE, type = "raw"),
+      c(-1.74547314271667, 0.0773903788154549)
+    )
+    expect_equal(
+      res_gamma(1:2, 2, 0.5, simulate = TRUE),
+      c(-0.682136415630992, -0.0483989592818978)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma(1:2, 2, 1, simulate = TRUE, type = "data"),
+      c(1.12726342864167, 2.03869518940773)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_gamma(1:2, 2, 1, simulate = TRUE, type = "standardized"),
+      c(-0.617117947796975, 0.0273616308295019)
+    )
+  })
+  withr::with_seed(101, {
+    res <- res_gamma(
+      rep(2, 10000), 2, 1, simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), 0.00754439840612374)
+    expect_equal(sd(res), 1.00440120529188)
+  })
 })
 
 test_that("res_student", {
-  expect_identical(res_student(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_student(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_student(1, 1, 0, 0), NaN)
   expect_identical(res_student(1, 1, 0.1, 0, type = "raw"), 0)
   expect_equal(res_student(2, 1, 1, 0.5), 1.10290313460634)
@@ -446,64 +732,130 @@ test_that("res_student", {
     res_student(c(1, 3.5, 4), 3, 10, 0.5, type = "raw"),
     c(-2, 0.5, 1)
   )
-  set.seed(101)
-  expect_equal(res_student(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-0.652072981030771, 1.10492371083828))
-  expect_equal(res_student(1:2, 2, 2, simulate = TRUE), c(-0.67494384395583, 0.214359459043425))
-  set.seed(101)
-  expect_equal(res_student(1:2, 2, 2, 0.5, simulate = TRUE, type = "raw"), c(-0.663122114744059, -1.65775518832743))
-  expect_equal(res_student(1:2, 2, 2, 0.5, simulate = TRUE), c(0.292028638517356, 1.05785074161446))
-  set.seed(101)
-  expect_equal(res_student(1:2, 2, 2, simulate = TRUE, type = "raw"), c(-0.652072981030771, 1.10492371083828))
-  expect_equal(res_student(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_student(1:2, 2, 2, 0.5, simulate = TRUE, type = "raw"), c(-0.663122114744059, -1.65775518832743))
-  expect_equal(res_student(1:2, 2, 0.5, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_student(1:2, 2, simulate = TRUE, type = "data"), c(1.67396350948461, 2.55246185541914))
-  set.seed(101)
-  expect_equal(res_student(1:2, 2, theta = 0.7, simulate = TRUE, type = "data"), c(1.38213662305365, 2.14557389211128))
-  set.seed(101)
-  expect_equal(res_student(1:2, 0, 0), res_norm(1:2, 0, 0))
-  expect_equal(res_student(1:2, 0, 0, 10), res_norm(1:2, 0, 0))
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-0.652072981030771, 1.10492371083828)
+    )
+    expect_equal(
+      res_student(1:2, 2, 2, simulate = TRUE),
+      c(-0.67494384395583, 0.214359459043425)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:2, 2, 2, 0.5, simulate = TRUE, type = "raw"),
+      c(-0.663122114744059, -1.65775518832743)
+    )
+    expect_equal(
+      res_student(1:2, 2, 2, 0.5, simulate = TRUE),
+      c(0.292028638517356, 1.05785074161446)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:2, 2, 2, simulate = TRUE, type = "raw"),
+      c(-0.652072981030771, 1.10492371083828)
+    )
+    expect_equal(res_student(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:2, 2, 2, 0.5, simulate = TRUE, type = "raw"),
+      c(-0.663122114744059, -1.65775518832743)
+    )
+    expect_equal(res_student(1:2, 2, 0.5, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:2, 2, simulate = TRUE, type = "data"),
+      c(1.67396350948461, 2.55246185541914)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:2, 2, theta = 0.7, simulate = TRUE, type = "data"),
+      c(1.38213662305365, 2.14557389211128)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(res_student(1:2, 0, 0), res_norm(1:2, 0, 0))
+    expect_equal(res_student(1:2, 0, 0, 10), res_norm(1:2, 0, 0))
+  })
   expect_equal(res_student(NA, 6, 0.5, 0.2, type = "standardized"), NA_real_)
   expect_equal(res_student(5, NA, 0.5, 0.2, type = "standardized"), NA_real_)
   expect_equal(res_student(5, 6, NA, 0.2, type = "standardized"), NA_real_)
   expect_equal(res_student(5, 6, 0.5, NA, type = "standardized"), NA_real_)
-  expect_equal(res_student(NA, NA, NA, NA, type = "standardized"), NA_real_)
-  expect_equal(res_student(numeric(0), numeric(0), numeric(0), numeric(0), type = "standardized"), numeric(0))
-  set.seed(101)
   expect_equal(
-    res_student(1:2, 5, 10, 1 / 5, simulate = TRUE, type = "standardized"),
-    c(-0.236216877861339, -0.543340118407321)
+    res_student(NA, NA, NA, NA, type = "standardized"),
+    NA_real_
   )
-  set.seed(101)
   expect_equal(
-    res_student(1:3, 5, 10, 0, simulate = TRUE, type = "standardized"),
-    c(-0.326036490515386, 0.552461855419139, -0.67494384395583)
+    res_student(
+      numeric(0), numeric(0), numeric(0), numeric(0),
+      type = "standardized"
+    ),
+    numeric(0)
   )
-  set.seed(101)
-  expect_equal(res_student(1:3, 5, 10, 1, simulate = TRUE, type = "standardized"), rep(NaN, 3))
-  set.seed(101)
-  expect_equal(res_student(1:3, 5, 10, 1 / 1.5, simulate = TRUE, type = "standardized"), rep(0, 3))
-  set.seed(101)
-  expect_equal(
-    res_student(1:3, 5, 10, 1 / 5, simulate = TRUE, type = "standardized"),
-    c(-0.236216877861339, -0.543340118407321, 0.190192700158201)
-  )
-  set.seed(101)
-  res <- res_student(rep(2, 10000), 5, 10, 1 / 5, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), 0.000136223967493112)
-  expect_equal(sd(res), 1.01150399649323)
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:2, 5, 10, 1 / 5, simulate = TRUE, type = "standardized"),
+      c(-0.236216877861339, -0.543340118407321)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:3, 5, 10, 0, simulate = TRUE, type = "standardized"),
+      c(-0.326036490515386, 0.552461855419139, -0.67494384395583)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:3, 5, 10, 1, simulate = TRUE, type = "standardized"),
+      rep(NaN, 3)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(
+        1:3, 5, 10, 1 / 1.5, simulate = TRUE, type = "standardized"
+      ),
+      rep(0, 3)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_student(1:3, 5, 10, 1 / 5, simulate = TRUE, type = "standardized"),
+      c(-0.236216877861339, -0.543340118407321, 0.190192700158201)
+    )
+  })
+  withr::with_seed(101, {
+    res <- res_student(
+      rep(2, 10000), 5, 10, 1 / 5,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), 0.000136223967493112)
+    expect_equal(sd(res), 1.01150399649323)
+  })
 })
 
 test_that("res_beta_binom", {
-  expect_identical(res_beta_binom(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_beta_binom(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_beta_binom(NA, 1, 1, 1), NA_real_)
   expect_identical(res_beta_binom(1, NA, 1, 1), NA_real_)
   expect_identical(res_beta_binom(1, 1, NA, 1), NA_real_)
   expect_identical(res_beta_binom(1, 1, 1, NA), NA_real_)
-  expect_equal(res_beta_binom(1, 3, 0.5), dev_beta_binom(1, 3, 0.5, res = TRUE))
-  expect_equal(res_beta_binom(1, 3, 0.5, 1.0), dev_beta_binom(1, 3, 0.5, 1.0, res = TRUE))
+  expect_equal(
+    res_beta_binom(1, 3, 0.5),
+    dev_beta_binom(1, 3, 0.5, res = TRUE)
+  )
+  expect_equal(
+    res_beta_binom(1, 3, 0.5, 1.0),
+    dev_beta_binom(1, 3, 0.5, 1.0, res = TRUE)
+  )
   expect_equal(res_beta_binom(0, 1, 0.5), -1.17741002251547)
   expect_equal(res_beta_binom(1, 1, 0.5), 1.17741002251547)
   expect_equal(res_beta_binom(0, 1, 0.7), -1.55175565365552)
@@ -521,68 +873,146 @@ test_that("res_beta_binom", {
   expect_equal(
     res_beta_binom(1:9, 10, 0.5),
     c(
-      -2.71316865369073, -1.96338868806845, -1.28283185573988, -0.634594572159089,
-      0, 0.634594572159089, 1.28283185573988, 1.96338868806845, 2.71316865369073
+      -2.71316865369073, -1.96338868806845,
+      -1.28283185573988, -0.634594572159089,
+      0, 0.634594572159089, 1.28283185573988,
+      1.96338868806845, 2.71316865369073
     )
   )
   expect_equal(
     res_beta_binom(1:9, 10, 0.5, 0.1),
     c(
-      -2.26648244134579, -1.61504974877637, -1.04572341572075, -0.51475735786997,
-      0, 0.514757357869973, 1.04572341572074, 1.61504974877637, 2.26648244134578
+      -2.26648244134579, -1.61504974877637,
+      -1.04572341572075, -0.51475735786997,
+      0, 0.514757357869973, 1.04572341572074,
+      1.61504974877637, 2.26648244134578
     )
   )
   expect_equal(res_beta_binom(0, 2, 0.5, type = "dev"), -1.6651092223154)
-  expect_equal(res_beta_binom(0, 2, 0.5, 10, type = "dev"), -1.24912654086732)
+  expect_equal(
+    res_beta_binom(0, 2, 0.5, 10, type = "dev"),
+    -1.24912654086732
+  )
   expect_equal(res_beta_binom(0, 2, 0.5, type = "raw"), -1)
   expect_equal(res_beta_binom(0, 2, 0.5, 10, type = "raw"), -1)
-  set.seed(101)
-  expect_equal(res_beta_binom(1:2, simulate = TRUE, type = "raw"), c(-0.5, -0.5))
-  expect_equal(res_beta_binom(1:2, 2, simulate = TRUE), c(0, 0))
-  set.seed(101)
-  expect_equal(res_beta_binom(1:2, theta = 2, simulate = TRUE, type = "raw"), c(0.5, -0.5))
-  expect_equal(res_beta_binom(1:2, 2, theta = 2, simulate = TRUE), c(0, 0))
-  set.seed(101)
-  expect_equal(res_beta_binom(1:2, simulate = TRUE, type = "raw"), c(-0.5, -0.5))
-  expect_equal(res_beta_binom(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_beta_binom(1:2, theta = 2, simulate = TRUE, type = "raw"), c(0.5, -0.5))
-  expect_equal(res_beta_binom(1:2, 2, theta = 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_beta_binom(1:2, 2, simulate = TRUE, type = "data"), 1:0)
-  expect_equal(res_beta_binom(1:2, 2, theta = 2, simulate = TRUE, type = "data"), c(0, 2))
-  set.seed(101)
+  withr::with_seed(101, {
+    expect_equal(
+      res_beta_binom(1:2, simulate = TRUE, type = "raw"),
+      c(-0.5, -0.5)
+    )
+    expect_equal(res_beta_binom(1:2, 2, simulate = TRUE), c(0, 0))
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_beta_binom(1:2, theta = 2, simulate = TRUE, type = "raw"),
+      c(0.5, -0.5)
+    )
+    expect_equal(
+      res_beta_binom(1:2, 2, theta = 2, simulate = TRUE),
+      c(0, 0)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_beta_binom(1:2, simulate = TRUE, type = "raw"),
+      c(-0.5, -0.5)
+    )
+    expect_equal(res_beta_binom(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_beta_binom(1:2, theta = 2, simulate = TRUE, type = "raw"),
+      c(0.5, -0.5)
+    )
+    expect_equal(
+      res_beta_binom(1:2, 2, theta = 2, type = "data"),
+      1:2
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_beta_binom(1:2, 2, simulate = TRUE, type = "data"),
+      1:0
+    )
+    expect_equal(
+      res_beta_binom(1:2, 2, theta = 2, simulate = TRUE, type = "data"),
+      c(0, 2)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_beta_binom(
+        1:2, 2, prob = 0.5, theta = 2,
+        simulate = TRUE, type = "standardized"
+      ),
+      c(0.816496580927726, -0.816496580927726)
+    )
+  })
   expect_equal(
-    res_beta_binom(1:2, 2, prob = 0.5, theta = 2, simulate = TRUE, type = "standardized"),
-    c(0.816496580927726, -0.816496580927726)
+    res_beta_binom(NA, 6, 0.5, 0.2, type = "standardized"),
+    NA_real_
   )
-  expect_equal(res_beta_binom(NA, 6, 0.5, 0.2, type = "standardized"), NA_real_)
-  expect_equal(res_beta_binom(5, NA, 0.5, 0.2, type = "standardized"), NA_real_)
-  expect_equal(res_beta_binom(5, 6, NA, 0.2, type = "standardized"), NA_real_)
-  expect_equal(res_beta_binom(5, 6, 0.5, NA, type = "standardized"), NA_real_)
-  expect_equal(res_beta_binom(NA, NA, NA, NA, type = "standardized"), NA_real_)
-  expect_equal(res_beta_binom(numeric(0), numeric(0), numeric(0), numeric(0), type = "standardized"), numeric(0))
-  set.seed(101)
   expect_equal(
-    res_beta_binom(1:2, 2, prob = 0.5, theta = 0, simulate = TRUE, type = "standardized"),
-    c(0, -1.4142135623731)
+    res_beta_binom(5, NA, 0.5, 0.2, type = "standardized"),
+    NA_real_
   )
-  set.seed(101)
-  res <- res_beta_binom(rep(2, 10000), size = 10, prob = 0.3, theta = 0.2, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), 0.0345591969703882)
-  expect_equal(sd(res), 2.24030672587351)
+  expect_equal(
+    res_beta_binom(5, 6, NA, 0.2, type = "standardized"),
+    NA_real_
+  )
+  expect_equal(
+    res_beta_binom(5, 6, 0.5, NA, type = "standardized"),
+    NA_real_
+  )
+  expect_equal(
+    res_beta_binom(NA, NA, NA, NA, type = "standardized"),
+    NA_real_
+  )
+  expect_equal(
+    res_beta_binom(
+      numeric(0), numeric(0), numeric(0), numeric(0),
+      type = "standardized"
+    ),
+    numeric(0)
+  )
+  withr::with_seed(101, {
+    expect_equal(
+      res_beta_binom(
+        1:2, 2, prob = 0.5, theta = 0,
+        simulate = TRUE, type = "standardized"
+      ),
+      c(0, -1.4142135623731)
+    )
+  })
+  withr::with_seed(101, {
+    res <- res_beta_binom(
+      rep(2, 10000), size = 10, prob = 0.3, theta = 0.2,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), 0.0345591969703882)
+    expect_equal(sd(res), 2.24030672587351)
+  })
   expect_error(res_beta_binom(10, type = "unknown"))
 })
 
 test_that("res_skewnorm", {
   skip_if_not_installed("sn")
-  expect_identical(res_skewnorm(integer(0), integer(0), integer(0)), numeric(0))
+  expect_identical(
+    res_skewnorm(integer(0), integer(0), integer(0)),
+    numeric(0)
+  )
   expect_identical(res_skewnorm(NA, 1, 1, 1), NA_real_)
   expect_identical(res_skewnorm(1, NA, 1, 1), NA_real_)
   expect_identical(res_skewnorm(1, 1, NA, 1), NA_real_)
   expect_identical(res_skewnorm(1, 1, 1, NA), NA_real_)
-  expect_equal(res_skewnorm(1, 3, 0.5), dev_skewnorm(1, 3, 0.5, res = TRUE))
-  expect_equal(res_skewnorm(1, 3, 0.5, 1.0), dev_skewnorm(1, 3, 0.5, 1.0, res = TRUE))
+  expect_equal(
+    res_skewnorm(1, 3, 0.5),
+    dev_skewnorm(1, 3, 0.5, res = TRUE)
+  )
+  expect_equal(
+    res_skewnorm(1, 3, 0.5, 1.0),
+    dev_skewnorm(1, 3, 0.5, 1.0, res = TRUE)
+  )
   expect_equal(res_skewnorm(0, 1, 0.5), -2)
   expect_equal(res_skewnorm(1, 1, 0.5), 0)
   expect_equal(res_skewnorm(0, 1, 0.7), -1.42857142857143)
@@ -600,55 +1030,124 @@ test_that("res_skewnorm", {
   expect_equal(
     res_skewnorm(1:9, 10, 0.5, 10),
     c(
-      -180.931340047915, -160.835052963763, -140.739643395107, -120.645509483193,
-      -100.553340951113, -80.4644530321068, -60.3817280342612, -40.3130604527845,
+      -180.931340047915, -160.835052963763,
+      -140.739643395107, -120.645509483193,
+      -100.553340951113, -80.4644530321068,
+      -60.3817280342612, -40.3130604527845,
       -20.2918769408978
     )
   )
   expect_equal(
     res_skewnorm(1:9, 10, 0.5, -10),
     c(
-      -17.9979431892188, -15.9976860527498, -13.9973554303071, -11.9969145634345,
-      -9.99629726660561, -7.99537110097754, -5.99382674443854, -3.99073414829236,
+      -17.9979431892188, -15.9976860527498,
+      -13.9973554303071, -11.9969145634345,
+      -9.99629726660561, -7.99537110097754,
+      -5.99382674443854, -3.99073414829236,
       -1.98140330128592
     )
   )
   expect_equal(res_skewnorm(0, 2, 0.5, type = "raw"), -2)
-  expect_equal(res_skewnorm(0, 2, 0.5, 10, type = "raw"), -1.60303759425339)
-  set.seed(101)
-  expect_equal(res_skewnorm(1:2, simulate = TRUE, type = "raw"), c(0.552461855419139, 0.214359459043425))
-  expect_equal(res_skewnorm(1:2, 2, simulate = TRUE), c(1.1739662875627, -0.112734314754215))
-  set.seed(101)
-  expect_equal(res_skewnorm(1:2, shape = 2, simulate = TRUE, type = "raw"), c(1.25233400157483, 1.41320223730144))
-  expect_equal(res_skewnorm(1:2, 2, shape = 2, simulate = TRUE), c(0.403578184606959, -0.0430501884150838))
-  set.seed(101)
-  expect_equal(res_skewnorm(1:2, simulate = TRUE, type = "raw"), c(0.552461855419139, 0.214359459043425))
-  expect_equal(res_skewnorm(1:2, 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_skewnorm(1:2, shape = 2, simulate = TRUE, type = "raw"), c(1.25233400157483, 1.41320223730144))
-  expect_equal(res_skewnorm(1:2, 2, shape = 2, type = "data"), 1:2)
-  set.seed(101)
-  expect_equal(res_skewnorm(1:2, 2, simulate = TRUE, type = "data"), c(2.55246185541914, 2.21435945904343))
-  expect_equal(res_skewnorm(1:2, 2, shape = 2, simulate = TRUE, type = "data"), c(2.8029741225477, 2.50304615414932))
-  set.seed(101)
   expect_equal(
-    res_skewnorm(1:2, 2, sd = 0.5, shape = 2, simulate = TRUE, type = "standardized"),
-    c(-0.713119218167245, -0.0574564315318186)
+    res_skewnorm(0, 2, 0.5, 10, type = "raw"),
+    -1.60303759425339
   )
-  expect_equal(res_skewnorm(NA, 6, 0.5, 0.2, type = "standardized"), NA_real_)
-  expect_equal(res_skewnorm(5, NA, 0.5, 0.2, type = "standardized"), NA_real_)
-  expect_equal(res_skewnorm(5, 6, NA, 0.2, type = "standardized"), NA_real_)
-  expect_equal(res_skewnorm(5, 6, 0.5, NA, type = "standardized"), NA_real_)
-  expect_equal(res_skewnorm(NA, NA, NA, NA, type = "standardized"), NA_real_)
-  expect_equal(res_skewnorm(numeric(0), numeric(0), numeric(0), numeric(0), type = "standardized"), numeric(0))
-  set.seed(101)
+  withr::with_seed(101, {
+    expect_equal(
+      res_skewnorm(1:2, simulate = TRUE, type = "raw"),
+      c(0.552461855419139, 0.214359459043425)
+    )
+    expect_equal(
+      res_skewnorm(1:2, 2, simulate = TRUE),
+      c(1.1739662875627, -0.112734314754215)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_skewnorm(1:2, shape = 2, simulate = TRUE, type = "raw"),
+      c(1.25233400157483, 1.41320223730144)
+    )
+    expect_equal(
+      res_skewnorm(1:2, 2, shape = 2, simulate = TRUE),
+      c(0.403578184606959, -0.0430501884150838)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_skewnorm(1:2, simulate = TRUE, type = "raw"),
+      c(0.552461855419139, 0.214359459043425)
+    )
+    expect_equal(res_skewnorm(1:2, 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_skewnorm(1:2, shape = 2, simulate = TRUE, type = "raw"),
+      c(1.25233400157483, 1.41320223730144)
+    )
+    expect_equal(res_skewnorm(1:2, 2, shape = 2, type = "data"), 1:2)
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_skewnorm(1:2, 2, simulate = TRUE, type = "data"),
+      c(2.55246185541914, 2.21435945904343)
+    )
+    expect_equal(
+      res_skewnorm(1:2, 2, shape = 2, simulate = TRUE, type = "data"),
+      c(2.8029741225477, 2.50304615414932)
+    )
+  })
+  withr::with_seed(101, {
+    expect_equal(
+      res_skewnorm(
+        1:2, 2, sd = 0.5, shape = 2,
+        simulate = TRUE, type = "standardized"
+      ),
+      c(-0.713119218167245, -0.0574564315318186)
+    )
+  })
   expect_equal(
-    res_skewnorm(1:2, 2, sd = 0.5, shape = 0, simulate = TRUE, type = "standardized"),
-    c(1.10492371083828, 0.428718918086851)
+    res_skewnorm(NA, 6, 0.5, 0.2, type = "standardized"),
+    NA_real_
   )
-  set.seed(101)
-  res <- res_skewnorm(rep(2, 10000), mean = 10, sd = 0.3, shape = 0.2, simulate = TRUE, type = "standardized")
-  expect_equal(mean(res), 0.0236707225149864)
-  expect_equal(sd(res), 3.34458775450197)
+  expect_equal(
+    res_skewnorm(5, NA, 0.5, 0.2, type = "standardized"),
+    NA_real_
+  )
+  expect_equal(
+    res_skewnorm(5, 6, NA, 0.2, type = "standardized"),
+    NA_real_
+  )
+  expect_equal(
+    res_skewnorm(5, 6, 0.5, NA, type = "standardized"),
+    NA_real_
+  )
+  expect_equal(
+    res_skewnorm(NA, NA, NA, NA, type = "standardized"),
+    NA_real_
+  )
+  expect_equal(
+    res_skewnorm(
+      numeric(0), numeric(0), numeric(0), numeric(0),
+      type = "standardized"
+    ),
+    numeric(0)
+  )
+  withr::with_seed(101, {
+    expect_equal(
+      res_skewnorm(
+        1:2, 2, sd = 0.5, shape = 0,
+        simulate = TRUE, type = "standardized"
+      ),
+      c(1.10492371083828, 0.428718918086851)
+    )
+  })
+  withr::with_seed(101, {
+    res <- res_skewnorm(
+      rep(2, 10000), mean = 10, sd = 0.3, shape = 0.2,
+      simulate = TRUE, type = "standardized"
+    )
+    expect_equal(mean(res), 0.0236707225149864)
+    expect_equal(sd(res), 3.34458775450197)
+  })
   expect_error(res_skewnorm(10, type = "unknown"))
 })


### PR DESCRIPTION
- prefix test names with the function under test
- replace `set.seed()` with `withr::with_seed()` blocks
- wrap all lines to ≤ 80 characters

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>