### PR TITLE
Add Stefano Mezzini as contributor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-1416-3412")),
     person("Nadine", "Hussein", role = "ctb",
            comment = c(ORCID = "0000-0003-4470-8361")),
+    person("Stefano", "Mezzini", role = "ctb",
+           comment = c(ORCID = "0000-0001-8551-7436")),
     person("Poisson Consulting", role = c("cph", "fnd"))
   )
 Description: Functions to 'numericise' 'R' objects (coerce to numeric


### PR DESCRIPTION
## Summary

Adds **Stefano Mezzini** (ORCID 0000-0001-8551-7436) as a contributor (`ctb`) in `DESCRIPTION`.

## Change

- `DESCRIPTION` — added a `person()` entry for Stefano Mezzini with role `"ctb"` and ORCID, matching the file's `Authors@R` formatting. No other files changed.

```
person("Stefano", "Mezzini", role = "ctb",
       comment = c(ORCID = "0000-0001-8551-7436")),
```

## Rationale

A review of the git history found Stefano contributed but was absent from `Authors@R`:

- **59 commits (~8% of the 709 total), +1,809 / -1,618 lines.**

Crediting as `ctb` matches the level at which other contributors at this scale are already listed in the package.

## Notes

- Contribution figures come from `git`/GitHub contributor statistics; commit and line counts are a proxy and were reviewed for substance.
- The updated `Authors@R` was verified to parse via `utils::as.person()`.
