### PR TITLE
Advance deprecation to warnings for as_list_unnamed(), pextreme(), and sextreme()

### DIFF
--- a/R/as-list.R
+++ b/R/as-list.R
@@ -2,12 +2,13 @@
 #'
 #' Coerces an object to an list.
 #' All attributes are removed except any names.
+#' `r lifecycle::badge('deprecated')`
 #'
 #' @inheritParams params
 #' @return A list.
 #' @export
 as_list_unnamed <- function(x, ...) {
-  lifecycle::deprecate_soft("0.1.1", "as_list_unnamed()", "as_list()")
+  lifecycle::deprecate_warn("0.10.0", "as_list_unnamed()", "as_list()")
   UseMethod("as_list_unnamed")
 }
 

--- a/R/pextreme.R
+++ b/R/pextreme.R
@@ -12,7 +12,7 @@
 #' @examples
 #' pextreme(seq(0, 1, by = 0.1))
 pextreme <- function(x) {
-  lifecycle::deprecate_soft("0.1.1", "pextreme()", id = "sextreme")
+  lifecycle::deprecate_warn("0.10.0", "pextreme()", id = "sextreme")
   chk_numeric(x)
   chk_range(x)
 

--- a/R/sextreme.R
+++ b/R/sextreme.R
@@ -14,7 +14,7 @@
 #' sextreme(seq(0.1, 0.9, by = 0.1))
 #' sextreme(seq(0.1, 0.9, by = 0.1), directional = TRUE)
 sextreme <- function(x, directional = FALSE) {
-  lifecycle::deprecate_soft("0.1.1", "sextreme()", id = "sextreme")
+  lifecycle::deprecate_warn("0.10.0", "sextreme()", id = "sextreme")
   chk_flag(directional)
   if (!length(x)) {
     return(numeric(0))

--- a/man/as_list_unnamed.Rd
+++ b/man/as_list_unnamed.Rd
@@ -20,6 +20,7 @@ A list.
 \description{
 Coerces an object to an list.
 All attributes are removed except any names.
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \examples{
 as_list_unnamed(1:3)

--- a/tests/testthat/test-as-list.R
+++ b/tests/testthat/test-as-list.R
@@ -5,6 +5,13 @@ test_that("as_list_unnamed works", {
   expect_identical(as_list_unnamed(integer(0)), list())
 })
 
+test_that("as_list_unnamed warns", {
+  lifecycle::expect_deprecated(
+    as_list_unnamed(1:2),
+    regexp = "as_list_unnamed.*deprecated.*as_list"
+  )
+})
+
 test_that("as_list works", {
   rlang::local_options(lifecycle_verbosity = "quiet")
   expect_identical(as_list(1:2), list(1L, 2L))

--- a/tests/testthat/test-pextreme.R
+++ b/tests/testthat/test-pextreme.R
@@ -12,3 +12,10 @@ test_that("pextreme", {
     c(0, NA_real_)
   )
 })
+
+test_that("pextreme warns", {
+  lifecycle::expect_deprecated(
+    pextreme(0.5),
+    regexp = "pextreme.*deprecated"
+  )
+})

--- a/tests/testthat/test-sextreme.R
+++ b/tests/testthat/test-sextreme.R
@@ -44,3 +44,12 @@ test_that("sextreme", {
     c(-Inf, NA_real_)
   )
 })
+
+test_that("sextreme warns", {
+  # sextreme() calls pextreme() internally (sharing id = "sextreme"), which
+  # also emits a deprecation warning once the id-based dedup is bypassed by
+  # forcing verbosity = "warning", so we can't assert a single exact match.
+  rlang::local_options(lifecycle_verbosity = "warning")
+  warnings <- testthat::capture_warnings(sextreme(0.5))
+  expect_match(warnings, "sextreme.*deprecated", all = FALSE)
+})


### PR DESCRIPTION
## Summary
- Escalates `pextreme()`, `sextreme()`, and `as_list_unnamed()` from `deprecate_soft()` to `deprecate_warn()`, so calls now warn unconditionally instead of only when invoked directly by user code
- Adds the missing lifecycle "deprecated" badge to `as_list_unnamed()`'s docs, matching `pextreme()`/`sextreme()`, and regenerates `man/as_list_unnamed.Rd`
- Adds tests confirming each function actually emits a deprecation warning now

## Test plan
- [x] `devtools::test()` — all tests pass, no stray warnings
- [x] `devtools::check()` — 0 errors, 0 warnings, 0 notes