### PR TITLE
Update test expectations for chk 0.11.0

### DIFF
--- a/tests/testthat/test-chk-pars.R
+++ b/tests/testthat/test-chk-pars.R
@@ -10,7 +10,7 @@ test_that("chk_pars", {
   x <- factor("a")
   expect_error(
     chk_pars(x),
-    "^`x` must inherit from S3 class 'character'[.]$",
+    "^`x` must inherit from S3 class 'character'",
     class = "chk_error"
   )
   x <- ".1"


### PR DESCRIPTION
Closes #142

chk 0.11.0 (about to be submitted to CRAN) improves its error messages: `chk::chk_s3_class()` errors now also state the object's actual class, e.g. ````x` must inherit from S3 class 'character', not S3 class 'factor'.``` This broke the anchored `expect_error()` regexp in `tests/testthat/test-chk-pars.R` (found via revdepcheck).

This PR drops the trailing `[.]$` anchor so the regexp is a prefix match. The test passes with both CRAN chk 0.10.0 and the upcoming chk 0.11.0, so it can be merged before or after the chk release. Verified locally with `devtools::test(filter = "chk-pars")` against a dev build of chk 0.11.0 (20 passed, 0 failed) and against chk 0.10.0.9028 (20 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)