### PR TITLE
Fix dev_skewnorm() residual sign to use the mode, not the mean

### DIFF
--- a/R/dev.R
+++ b/R/dev.R
@@ -389,7 +389,7 @@ dev_skewnorm <- function(x, mean = 0, sd = 1, shape = 0, res = FALSE) {
   if (vld_false(res)) {
     return(dev)
   }
-  dev_res(x, mean + sd * (shape / sqrt(1 + shape^2)) * sqrt(2 / pi), dev)
+  dev_res(x, mode_sat, dev)
 }
 
 #' Skew-Lognormal Deviances

--- a/tests/testthat/test-dev.R
+++ b/tests/testthat/test-dev.R
@@ -1006,6 +1006,18 @@ test_that("dev_skewnorm res", {
   )
 })
 
+test_that("dev_skewnorm res has no gap between the mode and the mean", {
+  skip_if_not_installed("sn")
+  # for shape != 0 the mode and mean of the fitted distribution differ;
+  # the deviance is 0 at the mode, so a point strictly between the mode
+  # and the mean must get a small-magnitude residual signed relative to
+  # the mode, not a large one signed relative to the mean
+  expect_equal(
+    dev_skewnorm(0.617181160588129, 0, 1, 3, res = TRUE),
+    0.24487123575488
+  )
+})
+
 test_that("dev_skewnorm log_lik", {
   skip_if_not_installed("sn")
   expect_equal(
@@ -1023,8 +1035,8 @@ test_that("dev_skewnorm ran", {
     expect_equal(mean(samples), 3.17851201086154)
     expect_equal(var(samples), 0.215894351753986)
     res <- dev_skewnorm(samples, 3, 0.5, 0.5, res = TRUE)
-    expect_equal(mean(res), 0.00818696278884169)
-    expect_equal(sd(res), 0.995441552601596)
+    expect_equal(mean(res), 0.00825163481429528)
+    expect_equal(sd(res), 0.995441018603231)
   })
 })
 


### PR DESCRIPTION
The deviance magnitude is computed relative to the fitted distribution's mode (mode_sat), since that is provably where the saturated log-likelihood is achieved for a location family. But the residual sign was computed relative to the theoretical mean instead. For skewed shapes, mode != mean, so points between the two got a small deviance (close to the mode) but the wrong sign (below the mean), producing a gap in the residual distribution where no small positive (or negative) residuals could occur. Use mode_sat for the sign too, matching the reference point used for the magnitude.

dev_skewlnorm() inherits the fix since it delegates to dev_skewnorm().