### PR TITLE
Move the fledge preamble back to the first line of NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
-# extras (development version)
-
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
 # extras 0.10.0


### PR DESCRIPTION
Closes #149

The daily `fledge-bump` workflow has been failing on extras with:

```
ℹ Can't act non-interactively on a 'NEWS.md' with no fledge-like preamble (HTML comment).
##[error]fledge::bump_version() did not create a tag.
```

A `# extras (development version)` heading sat above the fledge preamble, pushing the comment to line 3. Removing the heading restores it to line 1, matching term, nlist, chk and mcmcr.

## Verification

`fledge::bump_version()` gates on `fledgeling[["preamble_in_file"]]` and returns early when it is `FALSE`. Checked both ways against this working tree:

```
preamble_in_file (original NEWS.md): FALSE
preamble_in_file (fixed NEWS.md):    TRUE
```

So this flips the exact condition that was aborting the run.

The section under the removed heading was empty, so no release notes are lost. The diff is a two-line deletion.

## Notes

The heading looks like residue from a manual bump: the most recent `NEWS.md` commit, 749833ca "Bump version to 0.10.0.9000", lacks the `fledge:` prefix that the automated commits carry. `NEWS.md` is fledge-generated and should not be hand-edited.

Separately, the org-wide `fledge-bump` failures from 2026-08-28 to 2026-08-30 (`gert` unable to load `libgit2.so.1.7`) have cleared on their own; term, nlist, chk and mcmcr all bumped successfully on 08-31. This PR addresses the pre-existing extras-specific failure that those outages were masking.
