### PR TITLE
Fix raw and standardized residuals in res_skewnorm() (#152, #153)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,4 +53,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0.9000
+Config/roxygen2/version: 8.1.0.9000

--- a/R/res.R
+++ b/R/res.R
@@ -467,7 +467,7 @@ res_skewnorm <- function(
   switch(
     type,
     data = x,
-    raw = x - mean + sd * (shape / sqrt(1 + shape^2)) * sqrt(2 / pi),
+    raw = x - (mean + sd * (shape / sqrt(1 + shape^2)) * sqrt(2 / pi)),
     standardized = (x -
       (mean + sd * (shape / sqrt(1 + shape^2)) * sqrt(2 / pi))) /
       (sd^2 * (1 - ((2 * (shape / sqrt(1 + shape^2))^2) / pi))),

--- a/R/res.R
+++ b/R/res.R
@@ -470,7 +470,7 @@ res_skewnorm <- function(
     raw = x - (mean + sd * (shape / sqrt(1 + shape^2)) * sqrt(2 / pi)),
     standardized = (x -
       (mean + sd * (shape / sqrt(1 + shape^2)) * sqrt(2 / pi))) /
-      (sd^2 * (1 - ((2 * (shape / sqrt(1 + shape^2))^2) / pi))),
+      sqrt(sd^2 * (1 - ((2 * (shape / sqrt(1 + shape^2))^2) / pi))),
     dev = dev_skewnorm(x, mean = mean, sd = sd, shape = shape, res = TRUE),
     chk_subset(x, c("data", "raw", "dev", "standardized"))
   )

--- a/tests/testthat/test-res.R
+++ b/tests/testthat/test-res.R
@@ -1380,7 +1380,7 @@ test_that("res_skewnorm", {
         simulate = TRUE,
         type = "standardized"
       ),
-      c(-0.713119218167245, -0.0574564315318186)
+      c(-0.249771006896373, -0.020124195773685)
     )
   })
   expect_equal(
@@ -1423,7 +1423,7 @@ test_that("res_skewnorm", {
         simulate = TRUE,
         type = "standardized"
       ),
-      c(1.10492371083828, 0.428718918086851)
+      c(0.552461855419138, 0.214359459043425)
     )
   })
   withr::with_seed(101, {
@@ -1435,8 +1435,8 @@ test_that("res_skewnorm", {
       simulate = TRUE,
       type = "standardized"
     )
-    expect_equal(mean(res), 0.0236707225149864)
-    expect_equal(sd(res), 3.34458775450197)
+    expect_equal(mean(res), 0.0070137399798361)
+    expect_equal(sd(res), 0.991016173459387)
   })
   expect_error(res_skewnorm(10, type = "unknown"))
 })
@@ -1462,6 +1462,33 @@ test_that("res_skewnorm raw residuals subtract the mean", {
                         1, 2, shape, simulate = TRUE, type = "raw"
       )),
       0,
+      tolerance = 0.05
+    )
+  })
+})
+
+test_that("res_skewnorm standardized residuals divide by the sd", {
+  skip_if_not_installed("sn")
+  # with shape = 0 the skew normal is the normal
+  expect_equal(
+    res_skewnorm(-2:2, 1, 2, 0, type = "standardized"),
+    res_norm(-2:2, 1, 2, type = "standardized")
+  )
+  # otherwise they divide by sd * sqrt(1 - 2 * delta^2 / pi)
+  shape <- 5
+  delta <- shape / sqrt(1 + shape^2)
+  expect_equal(
+    res_skewnorm(-2:2, 1, 2, shape, type = "standardized"),
+    (-2:2 - (1 + 2 * delta * sqrt(2 / pi))) /
+      (2 * sqrt(1 - 2 * delta^2 / pi))
+  )
+  # so standardized residuals of data from the distribution have sd 1
+  withr::with_seed(101, {
+    expect_equal(
+      sd(res_skewnorm(rep(0, 10000), 1, 2, shape,
+        simulate = TRUE, type = "standardized"
+      )),
+      1,
       tolerance = 0.05
     )
   })

--- a/tests/testthat/test-res.R
+++ b/tests/testthat/test-res.R
@@ -1324,7 +1324,7 @@ test_that("res_skewnorm", {
   expect_equal(res_skewnorm(0, 2, 0.5, type = "raw"), -2)
   expect_equal(
     res_skewnorm(0, 2, 0.5, 10, type = "raw"),
-    -1.60303759425339
+    -2.39696240574661
   )
   withr::with_seed(101, {
     expect_equal(
@@ -1339,7 +1339,7 @@ test_that("res_skewnorm", {
   withr::with_seed(101, {
     expect_equal(
       res_skewnorm(1:2, shape = 2, simulate = TRUE, type = "raw"),
-      c(1.25233400157483, 1.41320223730144)
+      c(-0.174965291347390, -0.0140970556207733)
     )
     expect_equal(
       res_skewnorm(1:2, 2, shape = 2, simulate = TRUE),
@@ -1356,7 +1356,7 @@ test_that("res_skewnorm", {
   withr::with_seed(101, {
     expect_equal(
       res_skewnorm(1:2, shape = 2, simulate = TRUE, type = "raw"),
-      c(1.25233400157483, 1.41320223730144)
+      c(-0.174965291347390, -0.0140970556207733)
     )
     expect_equal(res_skewnorm(1:2, 2, shape = 2, type = "data"), 1:2)
   })
@@ -1439,6 +1439,32 @@ test_that("res_skewnorm", {
     expect_equal(sd(res), 3.34458775450197)
   })
   expect_error(res_skewnorm(10, type = "unknown"))
+})
+
+test_that("res_skewnorm raw residuals subtract the mean", {
+  skip_if_not_installed("sn")
+  # with shape = 0 the skew normal is the normal
+  expect_equal(
+    res_skewnorm(-2:2, 1, 2, 0, type = "raw"),
+    res_norm(-2:2, 1, 2, type = "raw")
+  )
+  # otherwise they are centred on mean + sd * delta * sqrt(2 / pi)
+  shape <- 5
+  delta <- shape / sqrt(1 + shape^2)
+  expect_equal(
+    res_skewnorm(-2:2, 1, 2, shape, type = "raw"),
+    -2:2 - (1 + 2 * delta * sqrt(2 / pi))
+  )
+  # so raw residuals of data from the distribution have mean 0
+  withr::with_seed(101, {
+    expect_equal(
+      mean(res_skewnorm(rep(0, 10000), # x values are irrelevant when simulating
+                        1, 2, shape, simulate = TRUE, type = "raw"
+      )),
+      0,
+      tolerance = 0.05
+    )
+  })
 })
 
 test_that("res_skewlnorm", {


### PR DESCRIPTION
Fixes two independent bugs in `res_skewnorm()` that were found while auditing the skew normal family. Both are one-line changes to `R/res.R`; the bulk of the diff is test updates.

**This PR was written by Claude Code**, working from an audit of the skew normal implementation. @StefanoMezzini is a co-author on both fix commits and reviewed the work.

## Closes #152 — `type = "raw"` added the skew correction instead of subtracting it

Missing parentheses meant operator precedence parsed the expression as `(x - mean) + correction` rather than `x - (mean + correction)`, so raw residuals were biased by `2 * sd * delta * sqrt(2 / pi)`:

```r
set.seed(1)
xs <- rskewnorm(1e5, 0, 1, 5)
mean(res_skewnorm(xs, 0, 1, 5, type = "raw"))
#> before: 1.567335
#> after:  0.00119711
```

## Closes #153 — `type = "standardized"` divided by the variance instead of the sd

The denominator was `sd^2 * (1 - 2 * delta^2 / pi)`, which is `Var(X)`, not `SD(X)`. Standardized residuals therefore did not have unit variance, and the function did not reduce to `res_norm()` at `shape = 0`:

```r
res_skewnorm(c(-1, 0, 1, 2), 1, 2, 0, type = "standardized")
#> before: -0.50 -0.25 0.00 0.25
#> after:  -1.00 -0.50 0.00 0.50
res_norm(c(-1, 0, 1, 2), 1, 2, type = "standardized")
#>         -1.00 -0.50 0.00 0.50
```

Over 10,000 simulated draws, `sd()` of the standardized residuals goes from 3.34 to 0.99.

## On the test changes

Seven existing expectations encoded the old behaviour and are updated here. That is most of the diff, so it is worth being explicit about why they were wrong rather than the code:

- The `raw` tests that exercised `shape = 0` still pass unchanged, because the skew correction vanishes there. Only the non-zero-`shape` cases moved.
- The `standardized` bug was invisible at `sd = 1`, where the variance and standard deviation coincide, and most surrounding tests use `sd = 1`. The one test that did use `sd = 0.5` asserted exactly double the correct value.

Each fix adds a `test_that()` block that would have caught its bug: equivalence with the corresponding `res_norm()` type at `shape = 0`, an explicit check of the centring and scaling terms, and a distributional check (mean ≈ 0 for `raw`, sd ≈ 1 for `standardized`) on simulated data.

`res_skewlnorm()` was already correct on both counts and is untouched.

## Also included

`5e373b02` (`update {roxygen2} to 8.1.0.9000`) is an unrelated `DESCRIPTION` version bump that was already on this branch, authored by @StefanoMezzini.

## Verification

Full test suite: 3230 passing, 0 failures, 19 pre-existing skips (`extraDistr` not installed locally, plus `skip_on_cran` in `test-sens.R`).

## Not addressed here

Six further issues from the same audit remain open and are out of scope for this PR: #154, #155, #156, #157, #158, #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
