### PR TITLE
Document shape as unbounded for sens_skewnorm() and sens_skewlnorm() (#158)

### DIFF
--- a/R/sens.R
+++ b/R/sens.R
@@ -57,6 +57,7 @@ sens_student <- function(mean, sd, theta, sd_mult = 2) {
 #' of the Skew Normal distribution without changing the mean.
 #'
 #' @inheritParams params
+#' @param shape A numeric vector of shape.
 #'
 #' @return A named list of the adjusted distribution's parameters.
 #' @family sens_dist
@@ -88,6 +89,7 @@ sens_skewnorm <- function(mean, sd, shape, sd_mult = 2) {
 #' `log(x)`), mirroring [sens_lnorm()], to which it reduces when `shape = 0`.
 #'
 #' @inheritParams params
+#' @param shape A numeric vector of shape.
 #'
 #' @return A named list of the adjusted distribution's parameters.
 #' @family sens_dist

--- a/man/sens_skewlnorm.Rd
+++ b/man/sens_skewlnorm.Rd
@@ -12,7 +12,7 @@ sens_skewlnorm(meanlog, sdlog, shape, sd_mult = 2)
 \item{sdlog}{A non-negative numeric vector of the standard deviations on the
 log scale.}
 
-\item{shape}{A non-negative numeric vector of shape.}
+\item{shape}{A numeric vector of shape.}
 
 \item{sd_mult}{A non-negative multiplier on the standard deviation of the
 distribution.}

--- a/man/sens_skewnorm.Rd
+++ b/man/sens_skewnorm.Rd
@@ -11,7 +11,7 @@ sens_skewnorm(mean, sd, shape, sd_mult = 2)
 
 \item{sd}{A non-negative numeric vector of the standard deviations.}
 
-\item{shape}{A non-negative numeric vector of shape.}
+\item{shape}{A numeric vector of shape.}
 
 \item{sd_mult}{A non-negative multiplier on the standard deviation of the
 distribution.}


### PR DESCRIPTION
Closes #158.

**This PR was created with Claude Code.** @StefanoMezzini is a co-author on the commit.

## Problem

`sens_skewnorm()` and `sens_skewlnorm()` relied on `@inheritParams params` for their `shape` argument, and `R/params.R` documents it as:

```
#' @param shape A non-negative numeric vector of shape.
```

For the skew normal, `shape` (`alpha` in `sn`) is unbounded — negative values give left skew and are fully supported. Both help pages already contradicted their own parameter documentation by demonstrating negative values:

```r
sens_skewnorm(10, 3, -1, 2)      # man/sens_skewnorm.Rd
```

## Fix

Add a local `@param shape A numeric vector of shape.` to both functions, matching what `dev_skewnorm()`, `res_skewnorm()`, `dskewnorm()` and friends already do, and re-document.

The shared entry in `params.R` is deliberately left alone. The issue raised the question of whether it should be relaxed instead; checking the other pages that still inherit the "non-negative" wording, they are all gamma functions:

```
dev_gamma  log_lik_gamma  prob_gamma  quant_gamma
ran_gamma  res_gamma      sens_gamma
```

The gamma shape parameter genuinely is non-negative, so the shared wording is correct as written and a local override is the right fix rather than a broader change.

## Scope

Documentation only — `R/sens.R` gains two roxygen lines, and the two `.Rd` files are regenerated. No change in behaviour.

The regenerated diff is confined to the two intended lines:

```diff
-\item{shape}{A non-negative numeric vector of shape.}
+\item{shape}{A numeric vector of shape.}
```

Note that roxygen 8.1.0.9000 is installed locally while `DESCRIPTION` on `main` records 8.0.0.9000, so re-documenting also bumps `Config/roxygen2/version`. That bump is unrelated to this issue and is already carried by #161, so it has been kept out of this branch.

## Verification

Both help pages' examples run, including the negative-`shape` ones, and `test-sens.R` passes (232 assertions, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
